### PR TITLE
chore(deps): bump lark-cli 1.0.71 → 1.0.72

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-bookworm-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d
 
 # Pin lark-cli to the version whose scope mapping is captured in shortcut-scopes.json.
 # Drift is detected by scripts/check-lark-cli-version.sh.
-ARG LARK_CLI_VERSION=1.0.71
+ARG LARK_CLI_VERSION=1.0.72
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get upgrade -y \

--- a/docker/__tests__/skill-quality.test.js
+++ b/docker/__tests__/skill-quality.test.js
@@ -231,4 +231,36 @@ describe.skipIf(skipIfNoSkills)('skill quality', () => {
       expect.fail(`${violations.length} resource file(s) unreachable (not referenced by any file in the skill):\n${report}`);
     }
   });
+
+  it('every script invoked with stdin= actually reads stdin (else the piped payload lands in /tmp/- and the call fails)', () => {
+    // Contract: the MCP container gives lark_exec_script child processes NO writable
+    // filesystem for the agent to stage an input file — stdin is the only data channel.
+    // So any adapted doc that calls lark_exec_script(script=X, ..., stdin="...") REQUIRES
+    // script X to read from stdin (typically `if path == "-": return sys.stdin.read()`).
+    // If it doesn't, `--input -` is resolved as the literal path /tmp/- and the tool call
+    // dies with FileNotFoundError. This static check keeps the docs and the scripts from
+    // drifting apart across lark-cli bumps (the failure mode is otherwise silent until a
+    // real tool call). See docs/skills/adapt-skill-for-mcp.md Rule 9.
+    const callRe = /lark_exec_script\(\s*script="([^"]+)"[^)]*\bstdin\b/g;
+    const offenders = [];
+    for (const file of allFiles) {
+      const content = readFileSync(file, 'utf8');
+      let m;
+      while ((m = callRe.exec(content)) !== null) {
+        const scriptRel = m[1]; // e.g. lark-slides/scripts/xml_text_overlap_lint.py
+        const scriptPath = join(SKILLS_DIR, scriptRel);
+        if (!existsSync(scriptPath)) {
+          offenders.push({ file: file.replace(SKILLS_DIR + '/', ''), script: scriptRel, reason: 'script file not found' });
+          continue;
+        }
+        if (!readFileSync(scriptPath, 'utf8').includes('sys.stdin')) {
+          offenders.push({ file: file.replace(SKILLS_DIR + '/', ''), script: scriptRel, reason: 'script does not read sys.stdin' });
+        }
+      }
+    }
+    if (offenders.length > 0) {
+      const report = offenders.map(o => `  ${o.file} → ${o.script}: ${o.reason}`).join('\n');
+      expect.fail(`${offenders.length} stdin-invoked script(s) that can't read stdin (piped payload would fail):\n${report}`);
+    }
+  });
 });

--- a/docker/rawapi-scopes.json
+++ b/docker/rawapi-scopes.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "lark_cli_version": "1.0.71",
+    "lark_cli_version": "1.0.72",
     "source": "lark-cli schema _meta.scopes"
   },
   "rawApis": [
@@ -570,7 +570,7 @@
       "resource": "user",
       "method": "remove_subscription",
       "scopes": [
-        "docs:event:subscribe"
+        "docs:document.comment:read"
       ]
     },
     {
@@ -578,7 +578,7 @@
       "resource": "user",
       "method": "subscription",
       "scopes": [
-        "docs:event:subscribe"
+        "docs:document.comment:read"
       ]
     },
     {
@@ -586,7 +586,7 @@
       "resource": "user",
       "method": "subscription_status",
       "scopes": [
-        "docs:event:subscribe"
+        "docs:document.comment:read"
       ]
     },
     {

--- a/docker/server.js
+++ b/docker/server.js
@@ -210,7 +210,17 @@ function execScript(script, args, stdin, abortSignal) {
       activeChildren.delete(child);
       if (err) {
         const code = typeof err.code === 'number' ? err.code : err.killed ? 'TIMEOUT' : err.code;
-        resolve({ error: 'exec_failed', message: stderr || err.message, exit_code: code });
+        // A non-zero exit does NOT mean there is no result: lint-style scripts print
+        // their full JSON to stdout and then exit 1 to signal severity (e.g. the slides
+        // linter exits 1 when error_count > 0). Dropping stdout here would hide exactly
+        // the findings the caller needs to act on. So if stdout parses as JSON, return
+        // it (the payload carries its own error_count); only fall back to exec_failed
+        // when there is no structured output to salvage (real crash / empty stdout).
+        try {
+          resolve(JSON.parse(stdout));
+        } catch {
+          resolve({ error: 'exec_failed', message: stderr || err.message, exit_code: code });
+        }
         return;
       }
       try {

--- a/docker/shortcut-scopes.json
+++ b/docker/shortcut-scopes.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "lark_cli_version": "1.0.71",
-    "extracted_at": "2026-07-16",
+    "lark_cli_version": "1.0.72",
+    "extracted_at": "2026-07-18",
     "source": "https://github.com/larksuite/cli"
   },
   "shortcuts": [

--- a/docker/skills/lark-approval/references/lark-approval-initiate.md
+++ b/docker/skills/lark-approval/references/lark-approval-initiate.md
@@ -68,17 +68,15 @@ lark_invoke(tool_name="lark_approval_approvals_get", args={params: {"approval_co
 |---|---|---|
 | `data` | 是 | 请求体，JSON 对象 |
 | `approval_code` | 是 | 审批定义 Code；必须先通过 `approvals search` / `approvals get` 确认 |
-| `form` | 是 | 表单值，**JSON 数组字符串**，不是普通对象 |
+| `form` | 否 | 表单值，**JSON 数组字符串**，不是普通对象；API 层非必填，但审批定义存在必填控件或用户需要提交表单值时必须传 |
 | `node_approver_list` | 否 | 节点审批人列表；仅在定义要求补充审批人时传 |
 | `node_cc_list` | 否 | 节点抄送人列表；仅在用户明确需要补充节点抄送人时传 |
 | `uuid` | 否 | 幂等标识；重复重试同一请求时建议显式传入 |
-| `params` | 否 | 查询参数，JSON 对象 |
-| `user_id_type` | 否 | 用户 ID 类型：`user_id`、`union_id`、`open_id`；涉及人员类 ID 时建议显式传 `open_id` |
 | `_confirm` | 是 | 高风险写操作确认；真实执行时必须显式传入 `_confirm=true` |
 
 ### 4. 组装 `form`
 
-`instances create` 请求体里的 `form` 是一个 JSON 数组字符串。组装原则：
+`instances create` 请求体里的 `form` 是可选字段；传入时必须是一个 JSON 数组字符串。无表单或无需填写表单值的审批可省略 `form`，但只要审批定义包含需要提交的控件，就必须按控件结构组装后传入。组装原则：
 
 - 先用 `approvals get` 返回的 `form` 识别有哪些控件、每个控件的 `id` / `type` / 可选值范围，再按本文中的创建参数规则与 `lark_get_skill(domain="approval", section="instance-form-control-parameters")` 重新组装创建 payload。
 - 提交时必须至少保证每个控件的 `id`、`type` 与 `value` 符合当前接口要求；不要假设定义快照里出现的其他字段都能直接照搬。
@@ -170,7 +168,6 @@ lark_invoke(tool_name="lark_approval_instances_create", args={
       }
     ]
   },
-  params: {"user_id_type":"open_id"},
   _confirm: true
 })
 ```

--- a/docker/skills/lark-approval/references/lark-approval-instances-initiated.md
+++ b/docker/skills/lark-approval/references/lark-approval-instances-initiated.md
@@ -13,6 +13,9 @@ lark_invoke(tool_name="lark_approval_instances_initiated", args={params: {"page_
 # 只看某个审批定义下我发起的实例
 lark_invoke(tool_name="lark_approval_instances_initiated", args={params: {"definition_code":"<DEFINITION_CODE>","page_size":20}})
 
+# 按发起时间范围筛选（秒级时间戳）
+lark_invoke(tool_name="lark_approval_instances_initiated", args={params: {"start_timestamp":"<START_SECONDS>","end_timestamp":"<END_SECONDS>","page_size":20}})
+
 # 使用 page_token 翻页
 lark_invoke(tool_name="lark_approval_instances_initiated", args={params: {"page_size":20,"page_token":"example_page_token"}})
 
@@ -26,6 +29,8 @@ lark_invoke(tool_name="lark_approval_instances_initiated", args={params: {"page_
 |------|------|------|
 | `params` | 否 | 查询参数，JSON 对象；不传时使用默认分页与筛选 |
 | `definition_code` | 否 | 审批定义 Code，用于只查看某个审批定义下我发起的实例 |
+| `start_timestamp` | 否 | 按发起时间筛选，时间范围开始值，秒级时间戳 |
+| `end_timestamp` | 否 | 按发起时间筛选，时间范围结束值，秒级时间戳 |
 | `locale` | 否 | 返回语言：`zh-CN`、`en-US`、`ja-JP` |
 | `page_size` | 否 | 分页大小 |
 | `page_token` | 否 | 翻页标记；首次请求不填，后续使用上一次返回的 `page_token` |
@@ -93,6 +98,7 @@ lark_invoke(tool_name="lark_approval_instances_initiated", args={params: {"defin
 
 - **这是定位“我发起的审批实例”的首选调用**：如果你的目标是撤回、抄送、查看某个已发起审批，优先从这里拿 `instance_code`。
 - **优先用 `definition_code` 缩小范围**：当你已知审批定义时，先筛掉无关实例，可显著提升可读性。
+- **按时间排查时使用 `start_timestamp` / `end_timestamp`**：这两个值都是秒级时间戳，用于按发起时间缩小结果范围。
 - **结果很多时优先 `format="table"`**：适合人工快速浏览。
 - **`count` 只在第一页返回**：做分页处理时不要假设后续页还会带总数。
 - **`instance_status` 可直接判断下一步**：例如状态为 `1` 时通常可继续查看详情或考虑撤回，状态为 `4` 表示已经撤销，无需重复撤回。

--- a/docker/skills/lark-approval/references/lark-approval-tasks-query.md
+++ b/docker/skills/lark-approval/references/lark-approval-tasks-query.md
@@ -13,6 +13,9 @@ lark_invoke(tool_name="lark_approval_tasks_query", args={params: {"topic":"1"}})
 # 查询已办审批
 lark_invoke(tool_name="lark_approval_tasks_query", args={params: {"topic":"2"}})
 
+# 按任务时间范围筛选（秒级时间戳）
+lark_invoke(tool_name="lark_approval_tasks_query", args={params: {"topic":"1","start_timestamp":"<START_SECONDS>","end_timestamp":"<END_SECONDS>"}})
+
 # 使用 page_token 翻页
 lark_invoke(tool_name="lark_approval_tasks_query", args={params: {"topic":"1","page_token":"example_page_token"}})
 
@@ -27,6 +30,8 @@ lark_invoke(tool_name="lark_approval_tasks_query", args={params: {"topic":"1"}, 
 | `params` | 是 | 查询参数，JSON 对象 |
 | `topic` | 是 | 任务分组主题，见下方“topic 枚举” |
 | `definition_code` | 否 | 审批定义 Code，用于仅查询某个审批定义下的任务 |
+| `start_timestamp` | 否 | 按任务时间筛选，时间范围开始值，秒级时间戳 |
+| `end_timestamp` | 否 | 按任务时间筛选，时间范围结束值，秒级时间戳 |
 | `locale` | 否 | 返回语言：`zh-CN`、`en-US`、`ja-JP` |
 | `page_size` | 否 | 分页大小 |
 | `page_token` | 否 | 翻页标记；首次请求不填，后续使用上一次返回的 `page_token` |
@@ -64,10 +69,14 @@ lark_invoke(tool_name="lark_approval_tasks_query", args={params: {"topic":"1"}, 
 | `tasks[].summaries` | 表单摘要字段列表 |
 | `tasks[].support_api_operate` | 是否支持通过 API 同意或拒绝该任务 |
 | `tasks[].user_id` | 任务所属用户 ID |
+| `tasks[].instance_external_id` | 三方审批实例 ID，仅第三方审批实例存在 |
+| `tasks[].task_external_id` | 三方审批任务 ID，仅第三方审批任务存在 |
+| `tasks[].link` | 三方审批跳转链接 |
 
 ## 使用建议
 
 - 常见处理链：先用 `tasks query` 拿到 `task_id` 和 `instance_code`，若用户需要查看详情、当前节点、表单内容、流程进度等内容，则调用 `instances get` 查看详情，最后执行 `tasks approve` / `tasks reject` / `tasks transfer` / `tasks add_sign` / `tasks rollback`。
 - 如果你只想看“已发起的审批实例”，使用 `instances initiated`；`tasks query` 更适合围绕“任务分组”来拉取列表。
+- 按时间排查任务时使用 `start_timestamp` / `end_timestamp` 缩小范围；这两个值都是秒级时间戳。
 - 需要继续翻页时，直接把上一次返回的 `page_token` 放回 `params`。
 - 当结果量较大时，优先使用 `format="table"` 提升可读性。

--- a/docker/skills/lark-approval/references/lark-approval-tasks-rollback.md
+++ b/docker/skills/lark-approval/references/lark-approval-tasks-rollback.md
@@ -13,6 +13,9 @@
 # 退回到单个节点
 lark_invoke(tool_name="lark_approval_tasks_rollback", args={data: {"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","node_ids":["<NODE_ID>"],"comment":"请补充附件后重新提交"}, _confirm: true})
 
+# 退回到发起节点（发起节点 ID 为 START）
+lark_invoke(tool_name="lark_approval_tasks_rollback", args={data: {"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","node_ids":["START"],"comment":"退回发起人补充材料"}, _confirm: true})
+
 # 传多个候选节点 ID（以实际审批定义支持情况为准）
 lark_invoke(tool_name="lark_approval_tasks_rollback", args={data: {"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","node_ids":["<NODE_ID_1>","<NODE_ID_2>"],"comment":"退回上一处理节点"}, _confirm: true})
 ```
@@ -24,7 +27,7 @@ lark_invoke(tool_name="lark_approval_tasks_rollback", args={data: {"instance_cod
 | `data` | 是 | 请求体，JSON 对象 |
 | `instance_code` | 是 | 审批实例 Code；通常先通过 `tasks query` 或 `instances initiated` / `instances get` 获取 |
 | `task_id` | 是 | 审批任务 ID；通常先通过 `tasks query` 获取 |
-| `node_ids` | 是 | 退回目标节点 ID 数组；执行前应先确认这些节点确实可作为退回目标 |
+| `node_ids` | 是 | 退回目标节点 ID 数组；发起节点 ID 为 `START`；执行前应先确认这些节点确实可作为退回目标 |
 | `comment` | 否 | 审批意见或退回说明，例如 `请补充附件后重新提交`、`预算说明不完整，请补充` |
 | `_confirm` | 是 | 确认执行高风险写操作；未带时会返回 `user_approval_required` |
 | `format` | 否 | 输出格式：`json`（默认）、`ndjson`、`table`、`csv` |
@@ -54,7 +57,7 @@ lark_invoke(tool_name="lark_approval_instances_get", args={params: {"instance_co
 ## 使用建议
 
 - **`instance_code` 和 `task_id` 要成对使用**：仅有实例 ID 或仅有任务 ID 都不足以准确执行退回操作。
-- **`node_ids` 是必填项**：退回并不是“自动退回上一步”，而是要明确给出目标节点 ID 数组。
+- **`node_ids` 是必填项**：退回并不是“自动退回上一步”，而是要明确给出目标节点 ID 数组；退回发起节点时传 `START`。
 - **先确认节点是否可退回**：不同审批定义支持的退回目标可能不同；在不确定时，先通过 `instances get` 或业务侧流程信息核实。
 - **优先从 `tasks query` 的待办列表拿任务参数**：尤其是 `topic=1` 的待办审批，最适合作为 rollback 的输入来源。
 - **先检查是否支持 API 操作**：如果 `tasks[].support_api_operate` 为 `false`，说明该任务可能不支持通过 API 执行处理动作，退回前应谨慎验证。

--- a/docker/skills/lark-base/references/lark-base-cell-value.md
+++ b/docker/skills/lark-base/references/lark-base-cell-value.md
@@ -16,15 +16,20 @@
 
 ## 2. 各类型 CellValue
 
-### 2.1 text / phone / url
+### 2.1 text
 
-用字符串。URL 字段也传 URL 字符串；普通文本里可以保留 Markdown 风格链接文本，平台会按字段类型处理。
+text 字段的 `style.type` 影响单元格检查逻辑：
+`type=plain` 传 Markdown 格式的字符串。
+`type=url` 传一个带 title 的 Markdown 格式链接，或单独传一个链接。
+`type=phone` 传合法电话号码。
+`type=email` 传合法邮箱字符串。
 
 ```json
 {
-    "标题": "Hello",
+    "标题": "Hello, [示例](https://example.com/docs)",
+    "官网": "[官网](https://example.com)",
     "联系电话": "1380000000000",
-    "官网": "https://example.com"
+    "邮箱": "owner@example.com"
 }
 ```
 

--- a/docker/skills/lark-base/references/lark-base-field-create.md
+++ b/docker/skills/lark-base/references/lark-base-field-create.md
@@ -15,9 +15,9 @@
 ```
 lark_base_field_create(json='{"name":"预算","type":"number","style":{"type":"plain","precision":2}}', base_token="<base_token>", table_id="<table_id>")
 
-lark_base_field_create(json='{"name":"状态","type":"select","multiple":false,"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Done","hue":"Green","lightness":"Light"}]}', base_token="<base_token>", table_id="<table_id>")
+lark_base_field_create(json='{"name":"状态","type":"select","multiple":false,"default_value":["Todo"],"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Done","hue":"Green","lightness":"Light"}]}', base_token="<base_token>", table_id="<table_id>")
 
-lark_base_field_create(json='{"name":"负责人","type":"user","multiple":false,"description":"用于标记记录的直接负责人；协作约定可参考[团队字段约定](https://example.com/field-spec)"}', base_token="<base_token>", table_id="<table_id>")
+lark_base_field_create(json='{"name":"负责人","type":"user","multiple":false,"default_value":[{"$slot":"current_user"}],"description":"用于标记记录的直接负责人；协作约定可参考[团队字段约定](https://example.com/field-spec)"}', base_token="<base_token>", table_id="<table_id>")
 ```
 
 ## 参数
@@ -40,6 +40,7 @@ POST /open-apis/base/v3/bases/:base_token/tables/:table_id/fields
 - `json` 必须是 **JSON 对象**，顶层直接传字段定义，不要再套一层。
 - 顶层最少包含：`name`、`type`。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接，如 `协作约定可参考[团队字段约定](https://example.com/field-spec)`。
+- 需要字段默认值时传 `default_value`，直接使用字段对应 CellValue；`datetime` / `user` 的动态填充用 `$slot`。完整规则见 `lark_get_skill(domain="base", section="field-json")`。
 - `type` 不同，必填子字段不同：
   - `select`：`multiple` 控制是否多选，`options` 定义静态选项，`dynamic_options_source` 定义动态选项来源。静态与动态选项配置二选一，不能同时传。
   - `link`：必须有 `link_table`，可选 `bidirectional`、`bidirectional_link_field_name`。
@@ -53,6 +54,7 @@ POST /open-apis/base/v3/bases/:base_token/tables/:table_id/fields
   "name": "状态",
   "type": "select",
   "multiple": false,
+  "default_value": ["Todo"],
   "options": [
     { "name": "Todo", "hue": "Blue", "lightness": "Lighter" },
     { "name": "Done", "hue": "Green", "lightness": "Light" }

--- a/docker/skills/lark-base/references/lark-base-field-json.md
+++ b/docker/skills/lark-base/references/lark-base-field-json.md
@@ -9,6 +9,7 @@
 - `json` 必须是 JSON 对象。
 - 顶层统一使用：`type` + `name` + 类型特有字段。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接。
+- 字段默认值使用 `default_value`，直接传对应 CellValue；支持范围只有 `text`、`number`、静态 `select`、`datetime`、`user`。清空默认值传 `null`；省略表示创建时不设置、更新时不修改。
 - 不要使用旧结构：`field_name`、`property`、`ui_type`、数字枚举 `type`。
 - `lark_base_field_update()` 使用同样的字段 JSON 结构，但语义是 `PUT`；这是高风险写入操作，建议先 `lark_base_field_get()` 再按目标状态全量提交，并带 `_confirm=true`。
 - `type=formula` 或 `type=lookup` 创建/更新前，必须先读对应 guide。
@@ -27,12 +28,12 @@
 
 | 类型 | 最小必填字段 | 常见补充字段 |
 |------|--------------|-------------|
-| `text` | `type` `name` | `style.type` |
-| `number` | `type` `name` | `style` |
-| `select` | `type` `name` | `multiple` + `options`，或 `multiple` + `dynamic_options_source` |
-| `datetime` | `type` `name` | `style.format` |
+| `text` | `type` `name` | `style.type` `default_value` |
+| `number` | `type` `name` | `style` `default_value` |
+| `select` | `type` `name` | `multiple` + `options` + 静态 `default_value`，或 `multiple` + `dynamic_options_source` |
+| `datetime` | `type` `name` | `style.format` `default_value` |
 | `created_at` / `updated_at` | `type` `name` | `style.format` |
-| `user` / `group_chat` | `type` `name` | `multiple` |
+| `user` / `group_chat` | `type` `name` | `multiple`；仅 `user` 支持 `default_value` |
 | `created_by` / `updated_by` | `type` `name` | 无 |
 | `link` | `type` `name` `link_table` | `bidirectional` `bidirectional_link_field_name` |
 | `formula` | `type` `name` `expression` | 无 |
@@ -47,31 +48,37 @@
 ### 3.1 text
 
 文本字段；电话、超链接、邮箱、条码也都属于 `text`，通过 `style.type` 区分。
+支持 `default_value`：静态 Markdown 文本字符串；`phone` style 必须是合法电话号码；`url` style 传一个 Markdown 链接或裸 URL；`email` style 必须是合法邮箱字符串，不要传 Markdown 链接或 `mailto:`。
 
 最小写法（默认 `style.type` 为 `plain`）：
 
 ```json
 {
   "type": "text",
-  "name": "标题"
+  "name": "标题",
+  "default_value": "默认标题"
 }
 ```
 
 常用写法：
 
+默认值可以是 Markdown 文本
 ```json
 {
   "type": "text",
   "name": "标题",
-  "description": "主标题字段"
+  "description": "主标题字段",
+  "default_value": "未命名"
 }
 ```
 
+`style.type=phone` 时默认值是合法电话号码字符串。
 ```json
 {
   "type": "text",
   "name": "联系电话",
-  "style": { "type": "phone" }
+  "style": { "type": "phone" },
+  "default_value": "+8613800000000"
 }
 ```
 
@@ -79,7 +86,17 @@
 {
   "type": "text",
   "name": "官网",
-  "style": { "type": "url" }
+  "style": { "type": "url" },
+  "default_value": "[官网](https://example.com)"
+}
+```
+
+```json
+{
+  "type": "text",
+  "name": "邮箱",
+  "style": { "type": "email" },
+  "default_value": "owner@example.com"
 }
 ```
 
@@ -88,13 +105,15 @@
 ### 3.2 number
 
 数字字段；货币、进度、评分都属于 `number`，通过 `style.type` 区分。
+支持 `default_value`：静态 JSON number；所有 number style 都按这个规则写。
 
 最小写法（默认 `style.type` 为 `plain`）：
 
 ```json
 {
   "type": "number",
-  "name": "工时"
+  "name": "工时",
+  "default_value": 8
 }
 ```
 
@@ -118,7 +137,8 @@
     "precision": 2,
     "percentage": false,
     "thousands_separator": true
-  }
+  },
+  "default_value": 8
 }
 ```
 
@@ -151,7 +171,8 @@
 {
   "type": "number",
   "name": "完成度",
-  "style": { "type": "progress", "percentage": true, "color": "Blue" }
+  "style": { "type": "progress", "percentage": true, "color": "Blue" },
+  "default_value": 0.65
 }
 ```
 
@@ -180,6 +201,7 @@
 #### 静态选项
 
 支持字段：`multiple`、`options`
+支持 `default_value`：静态选项名数组；即使 `multiple=false` 也写数组，如 `["Todo"]`。
 
 默认值 / 约束：
 - `multiple` 默认 `false`
@@ -189,12 +211,14 @@
 - `options[].hue` 可用：`Red`、`Orange`、`Yellow`、`Lime`、`Green`、`Turquoise`、`Wathet`、`Blue`、`Carmine`、`Purple`、`Gray` 缺省值为 `Blue`
 - `options[].lightness` 可用：`Lighter`、`Light`、`Standard`、`Dark`、`Darker` 缺省值为 `Lighter`
 - 选项里没有 `id`，只有 `name`。
+- 支持 `default_value` 配置：填选项名数组。
 
 ```json
 {
   "type": "select",
   "name": "状态",
   "multiple": false,
+  "default_value": ["Todo"],
   "options": [
     { "name": "Todo", "hue": "Blue", "lightness": "Lighter" },
     { "name": "Done", "hue": "Green", "lightness": "Light" }
@@ -205,6 +229,7 @@
 #### 动态选项
 
 支持字段：`multiple`、`dynamic_options_source`
+动态选项不支持 `default_value`。
 
 默认值 / 约束：
 - `multiple` 默认 `false`
@@ -213,6 +238,7 @@
 - `dynamic_options_source.field_id` 填来源字段 id 或字段名
 - `dynamic_options_source` 仅创建支持；更新已有字段时不要传
 - 引用选项条件 / 级联筛选条件：这个功能在 Base 前端支持，属于 UI-only 属性，OpenAPI 里不支持，不能读取、创建或更新；不要根据接口返回缺失判断未配置
+- 动态选项不支持配置 `default_value`。
 
 ```json
 {
@@ -229,13 +255,15 @@
 ### 3.4 datetime
 
 手动填写的日期/时间字段。系统时间用 `created_at` / `updated_at`。
+支持 `default_value`：静态时间字符串，或 `{ "$slot": "record_created_time" }`。`datetime + record_created_time` 是自动填充可编辑单元格；`created_at` 是只读创建时间元信息。
 
 最小写法：
 
 ```json
 {
   "type": "datetime",
-  "name": "截止时间"
+  "name": "截止时间",
+  "default_value": "2026-03-24 10:00:00"
 }
 ```
 
@@ -251,7 +279,8 @@
 {
   "type": "datetime",
   "name": "截止时间",
-  "style": { "format": "yyyy-MM-dd HH:mm" }
+  "style": { "format": "yyyy-MM-dd HH:mm" },
+  "default_value": { "$slot": "record_created_time" }
 }
 ```
 
@@ -276,12 +305,19 @@
 ### 3.6 user / group_chat
 
 人员字段和群字段都支持 `multiple`。
+`user` 支持 `default_value`：人员 CellValue 数组，元素可用 `{ "id": "ou_xxx" }` 或 `{ "$slot": "current_user" }`；不要猜用户 ID。`group_chat` 不支持默认值。
 
 默认值 / 约束：
 - `multiple` 默认 `true`
+- `user` 字段支持 `default_value` 配置，`group_chat` 字段不支持 `default_value` 配置。
 
 ```json
-{ "type": "user", "name": "负责人", "multiple": true }
+{
+  "type": "user",
+  "name": "负责人",
+  "multiple": true,
+  "default_value": [{ "$slot": "current_user" }, { "id": "ou_xxx" }]
+}
 ```
 
 ```json
@@ -488,3 +524,4 @@ Object（对象字段）、Button（按钮字段）、Stage（流程字段）暂
 - `number` 的精度、货币、进度、评分配置都放在 `style` 下，不要写顶层 `precision`。
 - `datetime` 是手动日期字段；系统时间请改用 `created_at` / `updated_at`。
 - `formula` / `lookup` 没读 guide 前不要直接写。
+- 只有 `text`、`number`、静态 `select`、`datetime`、`user` 支持 `default_value`；清空统一传 `"default_value": null`。其他字段类型不要配置默认值。

--- a/docker/skills/lark-base/references/lark-base-field-update.md
+++ b/docker/skills/lark-base/references/lark-base-field-update.md
@@ -5,9 +5,9 @@
 ## 推荐命令
 
 ```
-lark_base_field_update(json='{"name":"状态","type":"select","multiple":false,"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Doing","hue":"Orange","lightness":"Light"},{"name":"Done","hue":"Green","lightness":"Light"}]}', base_token="<base_token>", table_id="<table_id>", field_id="<field_id>")
+lark_base_field_update(json='{"name":"状态","type":"select","multiple":false,"default_value":["Doing"],"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Doing","hue":"Orange","lightness":"Light"},{"name":"Done","hue":"Green","lightness":"Light"}]}', base_token="<base_token>", table_id="<table_id>", field_id="<field_id>")
 
-lark_base_field_update(json='{"name":"负责人","type":"user","multiple":false,"description":"用于标记记录的直接负责人"}', base_token="<base_token>", table_id="<table_id>", field_id="<field_id>")
+lark_base_field_update(json='{"name":"负责人","type":"user","multiple":false,"default_value":null,"description":"用于标记记录的直接负责人"}', base_token="<base_token>", table_id="<table_id>", field_id="<field_id>")
 ```
 
 ## 参数
@@ -34,6 +34,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 - `json` 必须是 **JSON 对象**，顶层直接传字段定义。
 - 更新语义是 `PUT`（全量字段配置更新），不要只传零散片段；至少显式包含 `name`、`type`，并补齐该类型所需关键配置。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接。
+- 需要字段默认值时传 `default_value`，直接使用字段对应 CellValue；传 `null` 清空，省略表示不修改现有默认值。完整规则见 `lark_get_skill(domain="base", section="field-json")`。
 - `select` 更新时：`options` 仍按对象数组传，避免混入无效字段。
 - `link` 更新限制：
   - 不能把非 `link` 字段改成 `link`，也不能把 `link` 改成非 `link`。
@@ -46,6 +47,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
   "name": "状态",
   "type": "select",
   "multiple": false,
+  "default_value": ["Doing"],
   "options": [
     { "name": "Todo", "hue": "Blue", "lightness": "Lighter" },
     { "name": "Doing", "hue": "Orange", "lightness": "Light" },

--- a/docker/skills/lark-slides/references/slides_xml_schema_definition.xml
+++ b/docker/skills/lark-slides/references/slides_xml_schema_definition.xml
@@ -1464,6 +1464,7 @@
         <xs:annotation>
             <xs:documentation>
                 表格元素, 用于展示结构化数据
+                宽高分配规则参考 HTML table 的整体值 / 子项值处理逻辑, 但在 SXSD 中做确定化约束, 以保证跨端实现一致。
                 边框规则：
                 - 后设置优先：相邻单元格线条只有一个颜色, 如果均设置, 则右下单元格的设置覆盖左上单元格
                 - 不设置边框属性时使用默认样式
@@ -1476,6 +1477,8 @@
                 - id: 表格唯一标识符(可选)
                 - topLeftX/topLeftY: 左上角坐标
                 - flipX/flipY: 水平/垂直翻转
+                - width: 表格目标总宽度(可选)。若设置, 优先用于为未填写列宽的列分配剩余宽度; 当所有列宽均为空时, 所有列均分该值; 当所有列均已填写且该值大于已填写列宽总和时, 多出空间继续分配给现有列, 默认按各列当前宽度作为权重分配; 当已填写列宽之和超过或无法容纳该值时, 保留已填写列宽, 并以最终列宽总和回写 table.width
+                - height: 表格目标总高度(可选)。若设置, 优先用于为未填写行高的行分配剩余高度; 当所有行高均为空时, 所有行均分该值; 当所有行均已填写且该值大于已填写行高总和时, 多出空间继续分配给现有行, 默认按各行当前高度作为权重分配; 当已填写行高之和超过或无法容纳该值时, 保留已填写行高, 并以最终行高总和回写 table.height
                 table 子元素:
                 - colgroup: 列组元素, 用于定义列的宽度
                 - tr: 行元素, 包含多个单元格
@@ -1484,10 +1487,10 @@
                 - col: 列元素
                 col 属性:
                 - span: 列跨数, 默认为1, 可选
-                - width: 列宽度, 默认值为110, 可选
+                - width: 列宽度输入值, 默认值为110, 可选。无 table.width 时, 已填写列保持原值, 空列使用默认值; 有 table.width 时, 已填写列保持原值, 空列优先均分剩余宽度; 若不存在空列且 table.width 大于已填写列宽总和, 则多出空间按各列当前宽度作为权重分配到所有列; 若剩余宽度不足则空列回退为默认值, 并以最终列宽总和作为 table.width
 
                 tr 属性:
-                - height: 行高, 默认为单元格高度
+                - height: 行高输入值, 默认值为37, 可选。无 table.height 时, 已填写行保持原值, 空行使用默认值; 有 table.height 时, 已填写行保持原值, 空行优先均分剩余高度; 若不存在空行且 table.height 大于已填写行高总和, 则多出空间按各行当前高度作为权重分配到所有行; 若剩余高度不足则空行回退为默认值, 并以最终行高总和作为 table.height。若行高低于内容高度, 需要手动修改行高
                 tr 子元素:
                 - td: 单元格元素, 用于显示数据
 
@@ -1543,6 +1546,8 @@
             <xs:attribute name="topLeftY" type="sml:YType" use="required"/>
             <xs:attribute name="flipX" type="xs:boolean" use="optional" default="false"/>
             <xs:attribute name="flipY" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="width" type="sml:PositiveSize" use="optional"/>
+            <xs:attribute name="height" type="sml:PositiveSize" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/docker/skills/lark-slides/references/xml-format-guide.md
+++ b/docker/skills/lark-slides/references/xml-format-guide.md
@@ -248,6 +248,21 @@
 - `<tr>` 内为 `<td>`
 - `<td>` 内可放 `<content>`
 
+`<table>` 可选设置 `width` 和 `height`，分别表示表格的目标总宽度和总高度：
+
+```xml
+<table topLeftX="80" topLeftY="120" width="800" height="300">
+  <colgroup>
+    <col width="240"/>
+    <col/>
+  </colgroup>
+  <tr height="80">
+    <td><content textType="body"><p>表头 1</p></content></td>
+    <td><content textType="body"><p>表头 2</p></content></td>
+  </tr>
+</table>
+```
+
 ### `<chart>`
 
 图表元素必须至少包含：

--- a/docker/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/docker/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -69,6 +69,8 @@ def ensure_safe_xml_source(source: str) -> None:
 
 
 def read_file(file_path: str | Path) -> str:
+    if str(file_path) == "-":
+        return sys.stdin.read()
     return Path(file_path).read_text(encoding="utf-8")
 
 
@@ -1180,7 +1182,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
 
 
 def print_usage() -> None:
-    print("Usage:\n  python3 xml_text_overlap_lint.py --input <presentation.xml>", file=sys.stderr)
+    print("Usage:\n  python3 xml_text_overlap_lint.py --input <presentation.xml>\n  python3 xml_text_overlap_lint.py --input -   # read XML from stdin", file=sys.stderr)
 
 
 def run_cli(argv: list[str] | None = None) -> None:
@@ -1191,8 +1193,9 @@ def run_cli(argv: list[str] | None = None) -> None:
     if not options.get("input"):
         print_usage()
         fail("--input is required")
-    input_path = Path(options["input"]).resolve()
-    result = lint_xml(read_file(input_path), str(input_path))
+    input_arg = options["input"]
+    input_path = "-" if input_arg == "-" else str(Path(input_arg).resolve())
+    result = lint_xml(read_file(input_path), input_path)
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if result["summary"]["error_count"] > 0:
         raise SystemExit(1)

--- a/docker/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/docker/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -39,6 +39,8 @@ SXSD_ATTR_ALIASES = {
     "fontColor": "color",
 }
 SERVER_FILLED_SXSD_ATTRS = {"id"}
+DEFAULT_TABLE_COLUMN_WIDTH = 110
+DEFAULT_TABLE_ROW_HEIGHT = 37
 _SXSD_TAG_ATTRIBUTES_CACHE: dict[str, set[str]] | None = None
 _ICONPARK_ICON_TYPES_CACHE: set[str] | None = None
 
@@ -102,6 +104,84 @@ def extract_numeric_attribute(tag_source: str, name: str) -> int | float | None:
     except ValueError:
         return None
     return int(value) if value.is_integer() else value
+
+
+def sum_sizes(sizes: list[int | float]) -> int | float:
+    return sum(sizes)
+
+
+def is_filled_size(size: int | float | None) -> bool:
+    return isinstance(size, (int, float)) and math.isfinite(size) and size > 0
+
+
+def fill_last_size_gap(sizes: list[int | float], target_size: int | float) -> list[int | float]:
+    if not sizes:
+        return sizes
+    final_sizes = [
+        size if index == len(sizes) - 1 else max(1, math.floor(size + 0.5))
+        for index, size in enumerate(sizes)
+    ]
+    remaining_size = target_size - sum_sizes(final_sizes[:-1])
+    if remaining_size >= 1:
+        final_sizes[-1] = remaining_size
+        return final_sizes
+
+    size_to_redistribute = 1 - remaining_size
+    for index in range(len(final_sizes) - 2, -1, -1):
+        reduction = min(final_sizes[index] - 1, size_to_redistribute)
+        final_sizes[index] -= reduction
+        size_to_redistribute -= reduction
+        if size_to_redistribute == 0:
+            final_sizes[-1] = 1
+            return final_sizes
+
+    final_sizes[-1] = 1
+    return final_sizes
+
+
+def solve_weighted_min_layout(
+    input_sizes: list[int | float | None], default_size: int | float, target_min_size: int | float | None
+) -> dict[str, Any]:
+    filled_indexes: list[int] = []
+    empty_indexes: list[int] = []
+    base_sizes: list[int | float] = []
+    for index, size in enumerate(input_sizes):
+        if is_filled_size(size):
+            filled_indexes.append(index)
+            base_sizes.append(size)
+        else:
+            empty_indexes.append(index)
+            base_sizes.append(0)
+    filled_sum = sum_sizes(base_sizes)
+
+    if target_min_size is None:
+        final_sizes = [default_size if index in empty_indexes else size for index, size in enumerate(base_sizes)]
+        return {"final_sizes": final_sizes, "actual_size": sum_sizes(final_sizes), "ratio": 1}
+
+    if not filled_indexes:
+        average_size = target_min_size / len(input_sizes)
+        final_sizes = fill_last_size_gap([average_size] * len(input_sizes), target_min_size)
+        return {"final_sizes": final_sizes, "actual_size": sum_sizes(final_sizes), "ratio": 1}
+
+    if empty_indexes:
+        remaining_size = target_min_size - filled_sum
+        final_sizes = [*base_sizes]
+        if remaining_size > 0:
+            average_size = remaining_size / len(empty_indexes)
+            empty_sizes = fill_last_size_gap([average_size] * len(empty_indexes), remaining_size)
+            for index, empty_size in zip(empty_indexes, empty_sizes):
+                final_sizes[index] = empty_size
+        else:
+            for index in empty_indexes:
+                final_sizes[index] = default_size
+        return {"final_sizes": final_sizes, "actual_size": sum_sizes(final_sizes), "ratio": 1}
+
+    ratio = max(1, target_min_size / filled_sum)
+    actual_size = max(target_min_size, filled_sum)
+    if ratio == 1:
+        return {"final_sizes": [*base_sizes], "actual_size": actual_size, "ratio": ratio}
+    final_sizes = fill_last_size_gap([size * ratio for size in base_sizes], actual_size)
+    return {"final_sizes": final_sizes, "actual_size": sum_sizes(final_sizes), "ratio": ratio}
 
 
 def strip_xml(value: str) -> str:
@@ -531,8 +611,8 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
     for match in re.finditer(r"<(shape|img|table|chart|whiteboard)\b([^>]*)>", slide_xml):
         kind, attrs = match.group(1), match.group(2)
         content = ""
-        if kind == "shape":
-            close_index = slide_xml.find("</shape>", match.end())
+        if kind in {"shape", "table"}:
+            close_index = slide_xml.find(f"</{kind}>", match.end())
             if close_index != -1:
                 content = slide_xml[match.end() : close_index]
 
@@ -541,6 +621,14 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
         y = extract_numeric_attribute(attrs, "topLeftY")
         width = extract_numeric_attribute(attrs, "width")
         height = extract_numeric_attribute(attrs, "height")
+        table_layouts: dict[str, dict[str, Any] | None] = {}
+        if kind == "table":
+            width, table_layouts["width"] = resolve_table_dimension(
+                content, width, extract_table_column_sizes, DEFAULT_TABLE_COLUMN_WIDTH
+            )
+            height, table_layouts["height"] = resolve_table_dimension(
+                content, height, extract_table_row_sizes, DEFAULT_TABLE_ROW_HEIGHT
+            )
         if all(value is not None for value in [x, y, width, height]):
             element = {
                 "id": element_id,
@@ -552,6 +640,14 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "height": height,
                 "order": len(elements),
             }
+            if kind == "table":
+                element.update(
+                    {
+                        "declared_width": extract_numeric_attribute(attrs, "width"),
+                        "declared_height": extract_numeric_attribute(attrs, "height"),
+                        "table_layouts": table_layouts,
+                    }
+                )
             if kind == "shape":
                 element.update(
                     {
@@ -883,11 +979,129 @@ def detect_whiteboard_external_overlaps(
     return issues
 
 
+def detect_table_out_of_canvas(
+    elements: list[dict[str, Any]], slide_width: int | float, slide_height: int | float
+) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    for table in (element for element in elements if element["kind"] == "table"):
+        overflow = {
+            "left": max(-table["x"], 0),
+            "top": max(-table["y"], 0),
+            "right": max(table["x"] + table["width"] - slide_width, 0),
+            "bottom": max(table["y"] + table["height"] - slide_height, 0),
+        }
+        overflow_details = [
+            f"{side} by {amount:g}px" for side, amount in overflow.items() if amount > 0
+        ]
+        if not overflow_details:
+            continue
+        issues.append(
+            {
+                "level": "error",
+                "code": "table_out_of_canvas",
+                "elements": [table["id"]],
+                "canvas": {"width": slide_width, "height": slide_height},
+                "bbox": {
+                    "x": table["x"],
+                    "y": table["y"],
+                    "width": table["width"],
+                    "height": table["height"],
+                },
+                "overflow": overflow,
+                "message": (
+                    f'table {table["id"]} exceeds the {slide_width:g}x{slide_height:g} canvas '
+                    f'({", ".join(overflow_details)})'
+                ),
+                "hint": (
+                    "Move the table inside the canvas, reduce table.width/table.height, or split the table across "
+                    "slides."
+                ),
+            }
+        )
+    return issues
+
+
+def extract_table_column_sizes(table_xml: str) -> list[int | float | None]:
+    sizes: list[int | float | None] = []
+    for match in re.finditer(r"<col\b([^>]*)/?>", table_xml):
+        attrs = match.group(1)
+        span = extract_numeric_attribute(attrs, "span") or 1
+        span_count = int(span) if math.isfinite(span) and span > 0 and float(span).is_integer() else 1
+        sizes.extend([extract_numeric_attribute(attrs, "width")] * span_count)
+    return sizes
+
+
+def extract_table_row_sizes(table_xml: str) -> list[int | float | None]:
+    return [extract_numeric_attribute(match.group(1), "height") for match in re.finditer(r"<tr\b([^>]*)>", table_xml)]
+
+
+def resolve_table_dimension(
+    table_xml: str,
+    declared_size: int | float | None,
+    extract_sizes: Any,
+    default_size: int | float,
+) -> tuple[int | float | None, dict[str, Any] | None]:
+    input_sizes = extract_sizes(table_xml)
+    if not input_sizes:
+        return declared_size, None
+    layout = solve_weighted_min_layout(
+        input_sizes, default_size, declared_size if is_filled_size(declared_size) else None
+    )
+    return layout["actual_size"], layout
+
+
+def format_size(size: int | float) -> str:
+    return f"{size:g}"
+
+
+def detect_table_layout_size_mismatches(elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    dimensions = {
+        "width": ("col", "column widths"),
+        "height": ("tr", "row heights"),
+    }
+    for table in (element for element in elements if element["kind"] == "table"):
+        for dimension, (child_tag, child_description) in dimensions.items():
+            target_size = table[f"declared_{dimension}"]
+            if not is_filled_size(target_size):
+                continue
+            layout = table["table_layouts"][dimension]
+            if layout is None:
+                continue
+            actual_size = layout["actual_size"]
+            if math.isclose(actual_size, target_size, rel_tol=1e-9, abs_tol=1e-9):
+                continue
+            issues.append(
+                {
+                    "level": "info",
+                    "code": "table_resolved_size_mismatch",
+                    "elements": [table["id"]],
+                    "dimension": dimension,
+                    "declared_size": target_size,
+                    "resolved_size": actual_size,
+                    "resolved_sizes": layout["final_sizes"],
+                    "message": (
+                        f'table {table["id"]} declares {dimension}={format_size(target_size)}px, but its '
+                        f"{child_description} resolve to {format_size(actual_size)}px"
+                    ),
+                    "hint": (
+                        f"Set table.{dimension} to {format_size(actual_size)}px, or adjust <{child_tag}> sizes "
+                        f"so their resolved total matches {format_size(target_size)}px."
+                    ),
+                }
+            )
+    return issues
+
+
 def lint_slide(
     slide_xml: str, slide_number: int, slide_width: int | float = 960, slide_height: int | float = 540
 ) -> dict[str, Any]:
     elements = extract_elements(slide_xml)
-    issues: list[dict[str, Any]] = detect_whiteboard_external_overlaps(elements, slide_width, slide_height)
+    issues: list[dict[str, Any]] = [
+        *detect_whiteboard_external_overlaps(elements, slide_width, slide_height),
+        *detect_table_out_of_canvas(elements, slide_width, slide_height),
+        *detect_table_layout_size_mismatches(elements),
+    ]
 
     for index, left in enumerate(elements):
         for right in elements[index + 1 :]:
@@ -913,7 +1127,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
         return {
             "file": source_path,
             "slide_size": {"width": 960, "height": 540},
-            "summary": {"slide_count": 0, "error_count": 1, "warning_count": 0},
+            "summary": {"slide_count": 0, "error_count": 1, "warning_count": 0, "info_count": 0},
             "issues": [xml_error],
             "slides": [],
         }
@@ -925,10 +1139,16 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
     if namespace_issues:
         error_count = sum(1 for issue in top_level_issues if issue["level"] == "error")
         warning_count = sum(1 for issue in top_level_issues if issue["level"] == "warning")
+        info_count = sum(1 for issue in top_level_issues if issue["level"] == "info")
         return {
             "file": source_path,
             "slide_size": {"width": 960, "height": 540},
-            "summary": {"slide_count": 0, "error_count": error_count, "warning_count": warning_count},
+            "summary": {
+                "slide_count": 0,
+                "error_count": error_count,
+                "warning_count": warning_count,
+                "info_count": info_count,
+            },
             "issues": top_level_issues,
             "slides": [],
         }
@@ -941,10 +1161,17 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
     error_count += sum(1 for slide in slides for issue in slide["issues"] if issue["level"] == "error")
     warning_count = sum(1 for issue in top_level_issues if issue["level"] == "warning")
     warning_count += sum(1 for slide in slides for issue in slide["issues"] if issue["level"] == "warning")
+    info_count = sum(1 for issue in top_level_issues if issue["level"] == "info")
+    info_count += sum(1 for slide in slides for issue in slide["issues"] if issue["level"] == "info")
     result = {
         "file": source_path,
         "slide_size": {"width": presentation["width"], "height": presentation["height"]},
-        "summary": {"slide_count": len(slides), "error_count": error_count, "warning_count": warning_count},
+        "summary": {
+            "slide_count": len(slides),
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "info_count": info_count,
+        },
         "slides": slides,
     }
     if top_level_issues:

--- a/docker/skills/lark-vc-agent/SKILL.md
+++ b/docker/skills/lark-vc-agent/SKILL.md
@@ -102,7 +102,7 @@ lark_vc_detail(meeting_ids="<meeting_id>")
 ### 3. 发送会中文本或会中表情（写操作）
 
 1. 用户明确要求在当前进行中的会议里发送提示、说明、会中表情，或反馈"听不到 / 看不到 / 声音清楚 / 效果不错"时，用 `lark_vc_meeting_message_send`。
-2. 输入是长数字 `meeting_id`，不是 9 位会议号。若用户只给 9 位会议号，先用用户身份执行 `lark_vc_meeting_list_active` 并按 `meeting_no` 匹配，匹配到唯一会议后再发送；不要为了发消息尝试入会（入会是应用身份写操作，MCP 不可用）。
+2. 输入是长数字 `meeting_id`，不是 9 位会议号。若用户只给 9 位会议号，先用用户身份执行 `lark_vc_meeting_list_active` 并按 `meeting_no` 匹配，匹配到唯一会议后再发送；不要为了发消息尝试入会（入会是应用身份写操作，MCP 不可用）。发消息只需 `meeting_id`，不要先查 `lark_vc_detail`。
 3. 通过 MCP server 时身份始终是用户身份：用用户身份发现的 `meeting_id` 继续用用户身份发送，前提是当前用户正在该会议中。
 4. 文本消息使用 `text`；会中表情 / 反馈使用 `emoji_type`。`emoji_type` 必须从 `lark_get_skill(domain="vc-agent", section="meeting-message-send")` 里的完整列表中选择，大小写敏感。
 5. 支持普通 Feishu reaction emoji（如 `LOVE`、`SMILE`、`THUMBSUP`）和 4 个 VC 反馈 key（`VC_CanNotSee`、`VC_NoSound`、`VC_LooksGood`、`VC_SoundsClear`）。

--- a/docs/skills/adapt-skill-for-mcp.md
+++ b/docs/skills/adapt-skill-for-mcp.md
@@ -280,10 +280,23 @@ Handle them like this:
   `lark_exec_script(script="<relative-path>", args=[...])`. The `script` value is relative to
   the skills dir (e.g. `lark-slides/scripts/iconpark_tool.py`). Arguments are passed as a JSON
   array of strings.
-- **For scripts that read input from a file** (e.g. `--input <file>`): use the `stdin` parameter
-  if the script supports `--input -` (reading from stdin). The server pipes the `stdin` string to
-  the child process. If the script doesn't support stdin, note it in the skill and propose adding
-  the 2-line stdin support (see `xml_text_overlap_lint.py` for the pattern).
+- **For scripts that read input from a file** (e.g. `--input <file>`): the adapted `.md` MUST
+  invoke them via the `stdin` parameter (`args=["--input", "-"], stdin="<content>"`), because the
+  container gives `lark_exec_script` child processes **no writable filesystem** for the agent to
+  stage an input file — stdin is the only data channel. This is a hard contract: **if a doc pipes
+  `stdin=` to a script, that script MUST read stdin**, or the payload lands in the literal path
+  `/tmp/-` and the call dies with `FileNotFoundError`. So whenever you rewrite a file-reading
+  invocation to use `stdin`, first confirm the script reads stdin; if it doesn't, add the standard
+  2-line shim to its file-reading helper:
+
+  ```python
+  if str(file_path) == "-":
+      return sys.stdin.read()
+  ```
+
+  (Reference implementations: `doc_word_stat.py`, `xml_text_overlap_lint.py`.) The
+  `skill-quality` test "every script invoked with stdin= actually reads stdin" enforces this
+  statically — a doc/script drift fails CI rather than surfacing as a silent runtime error.
 - **Data files consumed by scripts** (e.g. `references/iconpark-index.json`,
   `assets/templates/*.xml`) stay at their current paths — the scripts locate them via
   `Path(__file__).parent.parent` which resolves correctly in the container.

--- a/docs/skills/bump-lark-cli.md
+++ b/docs/skills/bump-lark-cli.md
@@ -270,6 +270,28 @@ for d in "${READAPT[@]}"; do
 done
 ```
 
+> **⚠️ Verbatim `cp -r` CLOBBERS local script patches.** Some `.py` scripts carry
+> repo-local modifications that do NOT exist upstream and must survive the bump — the
+> **XXE guard** (`ensure_safe_xml_source` + `nosemgrep`, in `xml_text_overlap_lint.py` and
+> `doc_word_stat.py`) and the **stdin shim** (`if str(file_path) == "-": return sys.stdin.read()`,
+> required because the container has no writable FS — see
+> [`adapt-skill-for-mcp.md`](adapt-skill-for-mcp.md) Rule 9). A blind `cp -r` overwrites both.
+> For any script with local patches, do a **3-way merge** instead: take the NEW upstream file as
+> the baseline and re-apply the local hunks on top (as done for the 1.0.72 bump), rather than
+> letting the copy win. After copying, re-assert the patches survived:
+>
+> ```bash
+> # XXE guard present wherever it was before:
+> grep -L ensure_safe_xml_source docker/skills/lark-slides/scripts/xml_text_overlap_lint.py \
+>   docker/skills/lark-doc/scripts/doc_word_stat.py   # → prints nothing
+> # stdin shim present in both:
+> grep -L sys.stdin docker/skills/lark-slides/scripts/xml_text_overlap_lint.py \
+>   docker/skills/lark-doc/scripts/doc_word_stat.py   # → prints nothing
+> ```
+>
+> The `skill-quality` stdin-contract test also fails if the shim is lost on a script any doc
+> pipes `stdin=` to, but the XXE guard has no such test — verify it by grep here.
+
 Then confirm no orphan adapted dirs remain (runs against the **regenerated** tree, so do it
 here, not in Step 8):
 

--- a/infra/test/__snapshots__/snapshot.test.ts.snap
+++ b/infra/test/__snapshots__/snapshot.test.ts.snap
@@ -2108,7 +2108,7 @@ exports[`CDK Snapshot Tests > OAuthStack matches snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-west-2",
-          "S3Key": "05f7c48dbd805f200c333cf86f32b20549322cddf57317052e863b34567a067a.zip",
+          "S3Key": "fc63541ce86b17c66d87ac5f1dca5962ee3d0317912feb7bb59b67b9991c4181.zip",
         },
         "Environment": {
           "Variables": {

--- a/lambda/token-refresh-shim/scope-allowlist.ts
+++ b/lambda/token-refresh-shim/scope-allowlist.ts
@@ -83,7 +83,6 @@ export const SCOPE_ALLOWLIST: ReadonlySet<string> = new Set([
   "docs:document:copy",
   "docs:document:export",
   "docs:document:import",
-  "docs:event:subscribe",
   "docs:permission.member:apply",
   "docs:permission.member:auth",
   "docs:permission.member:create",


### PR DESCRIPTION
## English

Bumps lark-cli [1.0.71 → 1.0.72](https://github.com/larksuite/cli/releases/tag/v1.0.72), and re-adapts the changed skills per `docs/skills/bump-lark-cli.md`. A small patch release — scope extraction is byte-stable apart from one upstream scope rename, and the re-adaptation is incremental (4 domains with doc-only deltas).

### Upstream highlights

- **Approval** — time-range filters (`start_timestamp`/`end_timestamp`) on initiated-instance and task queries; rollback to the initiator node (`node_ids: ["START"]`); `form` is now API-optional; three new third-party output fields on task queries.
- **Base** — field `default_value` support, including `$slot` dynamic defaults (`current_user`, `record_created_time`) across text/number/select/datetime/user types.
- **Slides** — the XML lint script gains table width/height layout resolution and out-of-canvas / size-mismatch detection; the schema and format guide document the new table `width`/`height` attributes.
- **VC-agent** — a note that sending an in-meeting message only needs `meeting_id`, no prior detail lookup.

### Scope changes

- Scope mapping is otherwise unchanged. The only movement: three `docs` subscription raw APIs had their scope renamed upstream `docs:event:subscribe` → `docs:document.comment:read`, so `docs:event:subscribe` drops out of `scope-allowlist.ts`. No bot-only scope introduced; still user-identity only.

### Generated artifacts (17 files)

- `docker/Dockerfile` — `LARK_CLI_VERSION` 1.0.71 → 1.0.72.
- `docker/shortcut-scopes.json` / `docker/rawapi-scopes.json` — version metadata + the docs-subscription scope rename above.
- `lambda/token-refresh-shim/scope-allowlist.ts` — `docs:event:subscribe` removed.
- `docker/skills/**` — re-adapted approval / base / slides / vc-agent. **The slides `xml_text_overlap_lint.py` table-layout feature is merged on top of the repo's local XXE guard, which is preserved (not overwritten by the upstream copy).**
- `infra/test/__snapshots__/snapshot.test.ts.snap` — OAuth-shim asset hash follows `scope-allowlist.ts`.

### Verification

Pre-push `./scripts/test.sh` is green (unit, typecheck, lint, invariants; advisory docs-consistency check passed). Also run manually: `check-lark-cli-version`, tier1 scope coverage, the container smoke test (build + boot + MCP initialize/tools-list), and the built-catalog scans — boolean-flag misread (only the known `--allow-sensitive` false positive), CLI-speak leaks (0), payload schemas (25, matching baseline).

### Bundled fixes (2 `fix` commits)

Validating the slides linter end-to-end surfaced two **pre-existing** defects (both present before this bump, not caused by it). Fixed here since the bump is what exercised them:

1. **`fix(skills)` — slides lint script couldn't read stdin.** `xml_text_overlap_lint.py` only accepted `--input <path>`, but the adapted docs invoke it via `lark_exec_script(args=["--input", "-"], stdin=...)` — and the container gives script child processes no writable filesystem, so stdin is the only channel. `--input -` resolved to the literal path `/tmp/-` → `FileNotFoundError` on every call, blocking the slides create flow (lint is a pre-submit gate). Fix: read stdin when input is `-` (2-line shim mirroring `doc_word_stat.py`; XXE guard still runs on stdin). Guardrail: a new `skill-quality` static test asserts any script a doc pipes `stdin=` to actually reads stdin (mutation-verified). Docs: `adapt-skill-for-mcp.md` Rule 9 reframes stdin as a hard contract; `bump-lark-cli.md` warns that verbatim `cp -r` clobbers local script patches (XXE guard, stdin shim) and requires a 3-way merge.

2. **`fix(server)` — `lark_exec_script` dropped stdout on non-zero exit.** The wrapper returned only `{error:"exec_failed", stderr}` whenever a script exited non-zero, discarding stdout. But lint-style scripts print their full JSON and *then* `exit 1` to signal severity (the linter exits 1 when `error_count > 0`) — so the exact case the caller must act on (a table overflowing the canvas) lost its payload, silently defeating the gate. Fix: on non-zero exit, if stdout parses as JSON, return it; only fall back to `exec_failed` when there's no structured output to salvage (real crash / empty stdout, e.g. the XXE rejection). Verified end-to-end through the container: the out-of-canvas case now returns full JSON, the DOCTYPE-rejection case still returns `exec_failed`.

Both fixes were cross-reviewed by independent agents (correctness / test efficacy / doc accuracy) — all PASS.

### Upgrading

```bash
git pull && ./scripts/deploy.sh
```

No action required from end users.

---

## 中文

lark-cli [1.0.71 → 1.0.72](https://github.com/larksuite/cli/releases/tag/v1.0.72),并按 `docs/skills/bump-lark-cli.md` 重适配有变更的 skill。一个小 patch 版本:scope 抽取除一处上游 scope 改名外逐字不变,重适配为增量(4 个域,仅文档级改动)。

### 上游变更亮点

- **审批** — 已发起实例和任务查询支持时间范围过滤(`start_timestamp`/`end_timestamp`);支持回退到发起节点(`node_ids: ["START"]`);`form` 在 API 层改为可选;任务查询新增三个第三方输出字段。
- **多维表格** — 字段 `default_value` 默认值支持,含 `$slot` 动态默认值(`current_user`、`record_created_time`),覆盖 text/number/select/datetime/user 类型。
- **幻灯片** — XML lint 脚本新增表格宽高布局解算、超出画布 / 尺寸不一致检测;schema 和格式指南补充了表格 `width`/`height` 属性。
- **VC-agent** — 补充说明:发会中消息只需 `meeting_id`,不必先查 detail。

### scope 变化

- scope 映射其余部分不变。唯一变动:三个 `docs` 订阅类 raw API 的 scope 在上游从 `docs:event:subscribe` 改名为 `docs:document.comment:read`,于是 `docs:event:subscribe` 从 `scope-allowlist.ts` 移除。未引入任何 bot-only scope,仍为纯用户身份。

### 生成产物(17 个文件)

- `docker/Dockerfile` — `LARK_CLI_VERSION` 1.0.71 → 1.0.72。
- `docker/shortcut-scopes.json` / `docker/rawapi-scopes.json` — 版本元数据 + 上述 docs 订阅 scope 改名。
- `lambda/token-refresh-shim/scope-allowlist.ts` — 移除 `docs:event:subscribe`。
- `docker/skills/**` — 重适配 approval / base / slides / vc-agent。**幻灯片的 `xml_text_overlap_lint.py` 表格布局功能是叠加在仓库本地 XXE guard 之上合并的,guard 被保留(未被上游副本覆盖)。**
- `infra/test/__snapshots__/snapshot.test.ts.snap` — OAuth-shim 资源哈希随 `scope-allowlist.ts` 变化。

### 验证

pre-push `./scripts/test.sh` 全过(单测、typecheck、lint、invariants;advisory 文档一致性检查通过)。另外手动跑了:`check-lark-cli-version`、tier1 scope 覆盖、容器 smoke test(构建 + 启动 + MCP initialize/tools-list),以及构建产物扫描 —— boolean 误判(仅命中已知的 `--allow-sensitive` 假阳性)、CLI-speak 泄漏(0)、payload schema(25,与基线一致)。

### 随附修复(2 个 `fix` commit)

端到端验证幻灯片 lint 时,连带查出两个**既有缺陷**(都早于本次 bump,非本次引入)。因为是这次 bump 触发暴露的,一并在此修掉:

1. **`fix(skills)` —— 幻灯片 lint 脚本无法读 stdin。** `xml_text_overlap_lint.py` 只支持 `--input <路径>`,但适配文档用 `lark_exec_script(args=["--input", "-"], stdin=...)` 调它——容器不给脚本子进程可写文件系统,stdin 是唯一通道。`--input -` 被解析成字面路径 `/tmp/-` → 每次调用都 `FileNotFoundError`,卡住幻灯片创建流程(lint 是提交前强制门禁)。修复:input 为 `-` 时从 stdin 读(2 行 shim,对齐 `doc_word_stat.py`;XXE 护栏对 stdin 仍生效)。护栏:新增 `skill-quality` 静态测试,断言文档用 `stdin=` 调的脚本必须真读 stdin(已用变异测试验证)。文档:`adapt-skill-for-mcp.md` Rule 9 把 stdin 改为硬性契约;`bump-lark-cli.md` 警告 verbatim `cp -r` 会冲掉本地脚本补丁(XXE 护栏、stdin shim),要求走三方合并。

2. **`fix(server)` —— `lark_exec_script` 在非零退出时丢弃 stdout。** wrapper 只要脚本退出码非零就只返回 `{error:"exec_failed", stderr}`,把 stdout 丢掉。但 lint 类脚本是先打印完整 JSON、再 `exit 1` 来表达 severity(有 error 就 exit 1)——于是最需要处理的场景(表格超出画布)反而丢了结果,门禁形同虚设。修复:非零退出时若 stdout 是合法 JSON 就返回它;只有无结构化输出可救时(真 crash / stdout 空,如 XXE 拒绝)才退回 `exec_failed`。已通过容器端到端验证:超出画布用例现在返回完整 JSON,DOCTYPE 拒绝用例仍返回 `exec_failed`。

两个修复均经独立 agent 交叉 review(正确性 / 测试有效性 / 文档准确性)——全部 PASS。

### 升级

```bash
git pull && ./scripts/deploy.sh
```

终端用户无需额外操作。
