### PR TITLE
fix(docs): add offline_access to app-setup console-import scope list

### DIFF
--- a/docs/app-setup_en.md
+++ b/docs/app-setup_en.md
@@ -48,7 +48,7 @@ avoids that loop. It does **not** widen what users see at first authorization (s
 minimal set); the only cost is a larger declared permission ceiling and more items for
 your admin to approve.
 
-Scope list (212 entries, copy-paste ready):
+Scope list (213 entries, copy-paste ready):
 
 ```json
 {
@@ -208,6 +208,7 @@ Scope list (212 entries, copy-paste ready):
       "minutes:minutes:readonly",
       "minutes:minutes:update",
       "minutes:permission:apply",
+      "offline_access",
       "okr:okr.content:readonly",
       "okr:okr.content:writeonly",
       "okr:okr.period:readonly",

--- a/docs/app-setup_zh.md
+++ b/docs/app-setup_zh.md
@@ -38,7 +38,7 @@ Manager。请妥善保管，不要提交到代码库。
 反复。它**不影响**用户首次授权看到的范围（那始终是最小集），代价只是应用声明的权限上限更大、
 管理员审核项更多。
 
-scope 清单（212 条，可直接复制导入）：
+scope 清单（213 条，可直接复制导入）：
 
 ```json
 {
@@ -198,6 +198,7 @@ scope 清单（212 条，可直接复制导入）：
       "minutes:minutes:readonly",
       "minutes:minutes:update",
       "minutes:permission:apply",
+      "offline_access",
       "okr:okr.content:readonly",
       "okr:okr.content:writeonly",
       "okr:okr.period:readonly",

--- a/docs/skills/bump-lark-cli.md
+++ b/docs/skills/bump-lark-cli.md
@@ -138,8 +138,10 @@ then re-run `scripts/build-scope-allowlist.sh`.
 ### 6c. Refresh the scope list embedded in app-setup docs
 
 `docs/app-setup_{en,zh}.md` embed the console-import scope list — a snapshot of
-`scope-allowlist.ts` that is **user-only**, has `offline_access` removed, and also drops
-the scopes the Feishu/Lark console rejects on bulk import.
+`scope-allowlist.ts` that is **user-only** and drops the scopes the Feishu/Lark console
+rejects on bulk import. `offline_access` stays in the list: it imports fine, and the
+token endpoint only returns a refresh token when it is granted (skipping it breaks login
+refresh with error code 20027).
 
 Why the extra drop: `scope-allowlist.ts` is the runtime allowlist (union of shortcut +
 rawapi + oauth sources) used to validate incremental-auth requests. The rawapi source is
@@ -156,16 +158,16 @@ costs nothing. Importing any of these makes the console report "permission does 
 Regenerate the snapshot and diff it against both docs:
 
 ```bash
-node -e 'const g=JSON.parse(require("fs").readFileSync("config/console-rejected-scopes.json","utf8")); const DROP=new Set(Object.entries(g).filter(([k])=>!k.startsWith("_")).flatMap(([,v])=>v.scopes)); const s=[...require("fs").readFileSync("lambda/token-refresh-shim/scope-allowlist.ts","utf8").matchAll(/"([a-z][a-z0-9_:.\-]*)"/g)].map(m=>m[1]).filter(x=>x!=="offline_access"&&!DROP.has(x)); console.log(JSON.stringify({scopes:{tenant:[],user:[...new Set(s)].sort()}},null,2))'
+node -e 'const g=JSON.parse(require("fs").readFileSync("config/console-rejected-scopes.json","utf8")); const DROP=new Set(Object.entries(g).filter(([k])=>!k.startsWith("_")).flatMap(([,v])=>v.scopes)); const s=[...require("fs").readFileSync("lambda/token-refresh-shim/scope-allowlist.ts","utf8").matchAll(/"([a-z][a-z0-9_:.\-]*)"/g)].map(m=>m[1]).filter(x=>!DROP.has(x)); console.log(JSON.stringify({scopes:{tenant:[],user:[...new Set(s)].sort()}},null,2))'
 ```
 
 If the output differs from the ```json block in either doc, replace the block in both
 (they must stay byte-identical) and update the entry count in the surrounding prose
-("212 entries" / "212 条"). The `tenant` array stays empty — this project is
+("213 entries" / "213 条"). The `tenant` array stays empty — this project is
 user-identity only.
 
 `infra/test/scope-coverage.test.ts` guards this: it fails if either doc's list drifts
-from `allowlist − offline_access − console-rejected`, or if a rejected scope no longer
+from `allowlist − console-rejected`, or if a rejected scope no longer
 exists in the allowlist (a bump renamed/dropped it). If a bumped lark-cli adds a *new*
 console-rejected scope, that is the one case tests can't catch statically — a real
 bulk-import into a test app is the ground truth; add it to `console-rejected-scopes.json`.
@@ -380,7 +382,7 @@ Include all changed files:
 - [ ] No bot-only scopes in shortcut-scopes.json (e.g. `im:message:send_as_bot` should NOT appear)
 - [ ] `scripts/check-lark-cli-version.sh` passes
 - [ ] `npm test` passes (scope-coverage test catches missing oauth-scopes)
-- [ ] app-setup scope snapshot in sync (Step 6c): `scope-coverage.test.ts` passes its `app-setup … = allowlist − offline_access − console-rejected` assertions for both `docs/app-setup_{en,zh}.md` (regenerate per Step 6c if red)
+- [ ] app-setup scope snapshot in sync (Step 6c): `scope-coverage.test.ts` passes its `app-setup … = allowlist − console-rejected` assertions for both `docs/app-setup_{en,zh}.md` (regenerate per Step 6c if red)
 - [ ] `bash scripts/test-smoke-docker.sh` passes — the image **builds and the container boots** (catches a broken artifact that `npm test` cannot, e.g. a new module not `COPY`ed into the Dockerfile)
 - [ ] `git diff --stat` shows only the expected files (4-5 depending on oauth-scopes changes)
 - [ ] Re-adaptation scope is correct — the touched `docker/skills/` domains match the Step 8

--- a/infra/test/scope-coverage.test.ts
+++ b/infra/test/scope-coverage.test.ts
@@ -156,8 +156,10 @@ describe("scope coverage", () => {
   });
 
   // The console-import scope list embedded in docs/app-setup_{en,zh}.md is a derived
-  // snapshot of the allowlist: user-only, minus offline_access, minus the scopes the
-  // Feishu/Lark console rejects on bulk import (config/console-rejected-scopes.json).
+  // snapshot of the allowlist: user-only, minus the scopes the Feishu/Lark console
+  // rejects on bulk import (config/console-rejected-scopes.json). offline_access stays
+  // in the list — it imports fine and the token endpoint only returns a refresh token
+  // when it is granted (skipping it breaks login refresh with error code 20027).
   // These tests turn "remember to re-run bump-lark-cli Step 6c" into a hard failure.
   const allowlistScopes = new Set(
     [...allowlistSrc.matchAll(/^\s*"([^"]+)",?/gm)].map((m) => m[1]),
@@ -181,9 +183,9 @@ describe("scope coverage", () => {
   });
 
   for (const doc of ["docs/app-setup_en.md", "docs/app-setup_zh.md"]) {
-    it(`${doc} embeds the console-import list = allowlist − offline_access − console-rejected`, () => {
+    it(`${doc} embeds the console-import list = allowlist − console-rejected`, () => {
       const expected = [...allowlistScopes]
-        .filter((s) => s !== "offline_access" && !rejectedSet.has(s))
+        .filter((s) => !rejectedSet.has(s))
         .sort();
 
       const src = readFileSync(resolve(ROOT, doc), "utf-8");


### PR DESCRIPTION
## English

The console-import scope list embedded in `docs/app-setup_{en,zh}.md` was missing `offline_access`. Feishu returns a refresh token only when `offline_access` is granted, so an app configured strictly from the docs fails token refresh with error code **20027** ("current app lacks permission … enable offline_access in the developer console"). It bulk-imports fine along with the rest of the list.

### Changes

- `docs/app-setup_{en,zh}.md` — add `offline_access` to the import list (212 → 213), prose count synced.
- `infra/test/scope-coverage.test.ts` — drop the `!== "offline_access"` filter; the assertion is now `allowlist − console-rejected`.
- `docs/skills/bump-lark-cli.md` — sync Step 6c prose, the regenerator one-liner, the entry count, and the checklist.

### Verification

`./scripts/test.sh` offline suite green (incl. `scope-coverage.test.ts` 8/8).

### Deployed apps

Docs-only fix; already-deployed apps whose console never enabled `offline_access` need it enabled and a new app version published to stop hitting 20027.

---

## 中文

`docs/app-setup_{en,zh}.md` 里那份批量导入的 scope 清单漏了 `offline_access`。飞书只有在 `offline_access` 被授权时才返回 refresh token,因此严格照文档配置的应用,登录续期会失败、报错误码 **20027**(用户侧提示"当前应用权限不足…前往开发者后台开通 offline_access")。它能随清单一起正常批量导入。

### 改动

- `docs/app-setup_{en,zh}.md` — 导入清单加入 `offline_access`(212 → 213),散文条数同步。
- `infra/test/scope-coverage.test.ts` — 去掉 `!== "offline_access"` 过滤,断言改为 `allowlist − console-rejected`。
- `docs/skills/bump-lark-cli.md` — 同步 Step 6c 的说明、正则命令、条数与 checklist。

### 验证

`./scripts/test.sh` 离线套件全绿(含 `scope-coverage.test.ts` 8/8)。

### 已部署应用

纯文档修复;已部署、但后台从未开通 `offline_access` 的应用,需在后台开通并重新发版,才能不再撞上 20027。