### PR TITLE
docs(architecture): show both client onboarding paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Save and authorize in the browser when prompted. See [Connect clients](docs/conn
 
 ## Architecture
 
-Requests from a remote MCP client (e.g., Quick Desktop) → CloudFront → API Gateway → Middleware Lambda (MCP token verification + SigV4 signing) → AgentCore Runtime (MCP service container handles Feishu API calls). OAuth Lambda manages user authorization and auto-refreshes tokens every 30 minutes via EventBridge. All tokens encrypted in Secrets Manager (a dedicated KMS key only this service can decrypt).
+Requests from a remote MCP client (Kiro / Claude Code / Codex, which self-register via DCR, or Quick Desktop with a shared Client Secret) → CloudFront → API Gateway → Middleware Lambda (MCP token verification + SigV4 signing) → AgentCore Runtime (MCP service container handles Feishu API calls). OAuth Lambda manages user authorization and auto-refreshes tokens every 30 minutes via EventBridge. All tokens encrypted in Secrets Manager (a dedicated KMS key only this service can decrypt).
 
 <p align="center">
   <img src="docs/images/architecture-en.svg" alt="Architecture" width="720">
@@ -307,7 +307,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/aws-samples/sample-lark-mcp-
 
 ## 架构
 
-支持远程 MCP 的客户端（如 Quick Desktop）发起请求 → CloudFront → API Gateway → Middleware Lambda（验证 MCP Token + SigV4 签名）→ AgentCore Runtime（MCP 服务容器处理飞书 API 调用）。OAuth Lambda 负责用户授权和 Token 自动刷新（每 30 分钟），EventBridge 定时触发。所有 Token 加密存储在 Secrets Manager 中（专用 KMS 密钥，仅本服务可解密）。
+支持远程 MCP 的客户端（Kiro / Claude Code / Codex 走 DCR 自注册，Quick Desktop 用共享 Client Secret）发起请求 → CloudFront → API Gateway → Middleware Lambda（验证 MCP Token + SigV4 签名）→ AgentCore Runtime（MCP 服务容器处理飞书 API 调用）。OAuth Lambda 负责用户授权和 Token 自动刷新（每 30 分钟），EventBridge 定时触发。所有 Token 加密存储在 Secrets Manager 中（专用 KMS 密钥，仅本服务可解密）。
 
 <p align="center">
   <img src="docs/images/architecture.svg" alt="Architecture" width="720">

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Save and authorize in the browser when prompted. See [Connect clients](docs/conn
 
 ## Architecture
 
-Requests from a remote MCP client (Kiro / Claude Code / Codex, which self-register via DCR, or Quick Desktop with a shared Client Secret) → CloudFront → API Gateway → Middleware Lambda (MCP token verification + SigV4 signing) → AgentCore Runtime (MCP service container handles Feishu API calls). OAuth Lambda manages user authorization and auto-refreshes tokens every 30 minutes via EventBridge. All tokens encrypted in Secrets Manager (a dedicated KMS key only this service can decrypt).
+Requests from a remote MCP client (Kiro / Claude Code / Codex, which self-register via DCR, or Amazon Quick with a shared Client Secret) → CloudFront → API Gateway → Middleware Lambda (MCP token verification + SigV4 signing) → AgentCore Runtime (MCP service container handles Feishu API calls). OAuth Lambda manages user authorization and auto-refreshes tokens every 30 minutes via EventBridge. All tokens encrypted in Secrets Manager (a dedicated KMS key only this service can decrypt).
 
 <p align="center">
   <img src="docs/images/architecture-en.svg" alt="Architecture" width="720">
@@ -307,7 +307,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/aws-samples/sample-lark-mcp-
 
 ## 架构
 
-支持远程 MCP 的客户端（Kiro / Claude Code / Codex 走 DCR 自注册，Quick Desktop 用共享 Client Secret）发起请求 → CloudFront → API Gateway → Middleware Lambda（验证 MCP Token + SigV4 签名）→ AgentCore Runtime（MCP 服务容器处理飞书 API 调用）。OAuth Lambda 负责用户授权和 Token 自动刷新（每 30 分钟），EventBridge 定时触发。所有 Token 加密存储在 Secrets Manager 中（专用 KMS 密钥，仅本服务可解密）。
+支持远程 MCP 的客户端（Kiro / Claude Code / Codex 走 DCR 自注册，Amazon Quick 用共享 Client Secret）发起请求 → CloudFront → API Gateway → Middleware Lambda（验证 MCP Token + SigV4 签名）→ AgentCore Runtime（MCP 服务容器处理飞书 API 调用）。OAuth Lambda 负责用户授权和 Token 自动刷新（每 30 分钟），EventBridge 定时触发。所有 Token 加密存储在 Secrets Manager 中（专用 KMS 密钥，仅本服务可解密）。
 
 <p align="center">
   <img src="docs/images/architecture.svg" alt="Architecture" width="720">

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -10,7 +10,7 @@ rather than trusting line numbers.
 
 ## Request lifecycle (one tool call)
 
-Client (remote-MCP, e.g. Quick Desktop)
+Client (remote-MCP: Kiro / Claude Code / Codex via DCR, or Quick Desktop)
   → CloudFront (HTTPS edge, optional WAFv2 rate limiting)
   → API Gateway
   → Middleware Lambda  (`lambda/mcp-middleware/index.ts`)

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -10,7 +10,7 @@ rather than trusting line numbers.
 
 ## Request lifecycle (one tool call)
 
-Client (remote-MCP: Kiro / Claude Code / Codex via DCR, or Quick Desktop)
+Client (remote-MCP: Kiro / Claude Code / Codex via DCR, or Amazon Quick)
   → CloudFront (HTTPS edge, optional WAFv2 rate limiting)
   → API Gateway
   → Middleware Lambda  (`lambda/mcp-middleware/index.ts`)

--- a/docs/images/architecture-en.svg
+++ b/docs/images/architecture-en.svg
@@ -46,7 +46,7 @@
   <text x="415" y="63" text-anchor="middle" font-size="9" fill="#666">self-register (DCR) + PKCE · no secret</text>
 
   <rect x="560" y="26" width="180" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
-  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Quick Desktop</text>
+  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Amazon Quick</text>
   <text x="650" y="63" text-anchor="middle" font-size="9" fill="#666">shared Client ID + Secret</text>
 
   <line x1="415" y1="74" x2="415" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>

--- a/docs/images/architecture-en.svg
+++ b/docs/images/architecture-en.svg
@@ -46,7 +46,7 @@
   <text x="415" y="63" text-anchor="middle" font-size="9" fill="#666">self-register (DCR) + PKCE · no secret</text>
 
   <rect x="560" y="26" width="180" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
-  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Amazon Quick</text>
+  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Quick Desktop</text>
   <text x="650" y="63" text-anchor="middle" font-size="9" fill="#666">shared Client ID + Secret</text>
 
   <line x1="415" y1="74" x2="415" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>

--- a/docs/images/architecture-en.svg
+++ b/docs/images/architecture-en.svg
@@ -9,7 +9,7 @@
   <text x="980" y="22" text-anchor="end" fill="#aaa" font-size="10">tag: project=lark-mcp-on-agentcore</text>
 
   <!-- Layer labels (vertically aligned with each layer's content) -->
-  <text x="22" y="64" fill="#aaa" font-size="11">Client</text>
+  <text x="22" y="54" fill="#aaa" font-size="11">Client</text>
   <text x="22" y="148" fill="#aaa" font-size="11">Edge</text>
   <text x="22" y="274" fill="#aaa" font-size="11">Compute</text>
   <text x="22" y="424" fill="#aaa" font-size="11">Runtime</text>
@@ -40,11 +40,18 @@
   <text x="890" y="348" text-anchor="middle" font-size="9" fill="#666">CloudWatch · SNS</text>
   <text x="890" y="362" text-anchor="middle" font-size="9" fill="#666">TokenLost / RefreshFailed</text>
 
-  <!-- ===== Layer 1: Quick Desktop ===== -->
-  <rect x="506" y="38" width="160" height="44" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
-  <text x="586" y="64" text-anchor="middle" font-size="13" font-weight="500">Quick Desktop</text>
-  <line x1="586" y1="82" x2="586" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="594" y="96" fill="#666" font-size="10">HTTPS</text>
+  <!-- ===== Layer 1: clients (two onboarding paths) ===== -->
+  <rect x="300" y="26" width="230" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
+  <text x="415" y="46" text-anchor="middle" font-size="13" font-weight="500">Kiro · Claude Code · Codex</text>
+  <text x="415" y="63" text-anchor="middle" font-size="9" fill="#666">self-register (DCR) + PKCE · no secret</text>
+
+  <rect x="560" y="26" width="180" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
+  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Amazon Quick</text>
+  <text x="650" y="63" text-anchor="middle" font-size="9" fill="#666">shared Client ID + Secret</text>
+
+  <line x1="415" y1="74" x2="415" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="650" y1="74" x2="650" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="533" y="90" text-anchor="middle" fill="#666" font-size="10">HTTPS</text>
 
   <!-- ===== Layer 2: Edge ===== -->
   <rect x="80" y="100" width="700" height="88" rx="8" fill="#f8f9fa" stroke="#bbb" stroke-width="1"/>

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -9,7 +9,7 @@
   <text x="980" y="22" text-anchor="end" fill="#aaa" font-size="10">tag: project=lark-mcp-on-agentcore</text>
 
   <!-- Layer labels (vertically aligned with each layer's content) -->
-  <text x="22" y="64" fill="#aaa" font-size="11">客户端</text>
+  <text x="22" y="54" fill="#aaa" font-size="11">客户端</text>
   <text x="22" y="148" fill="#aaa" font-size="11">入口</text>
   <text x="22" y="274" fill="#aaa" font-size="11">计算</text>
   <text x="22" y="424" fill="#aaa" font-size="11">运行时</text>
@@ -40,11 +40,18 @@
   <text x="890" y="348" text-anchor="middle" font-size="9" fill="#666">CloudWatch · SNS</text>
   <text x="890" y="362" text-anchor="middle" font-size="9" fill="#666">TokenLost / RefreshFailed</text>
 
-  <!-- ===== Layer 1: Quick Desktop ===== -->
-  <rect x="506" y="38" width="160" height="44" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
-  <text x="586" y="64" text-anchor="middle" font-size="13" font-weight="500">Quick Desktop</text>
-  <line x1="586" y1="82" x2="586" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="594" y="96" fill="#666" font-size="10">HTTPS</text>
+  <!-- ===== Layer 1: 客户端（两条接入路径） ===== -->
+  <rect x="300" y="26" width="230" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
+  <text x="415" y="46" text-anchor="middle" font-size="13" font-weight="500">Kiro · Claude Code · Codex</text>
+  <text x="415" y="63" text-anchor="middle" font-size="9" fill="#666">自注册 (DCR) + PKCE · 无需 Secret</text>
+
+  <rect x="560" y="26" width="180" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
+  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Amazon Quick</text>
+  <text x="650" y="63" text-anchor="middle" font-size="9" fill="#666">共享 Client ID + Secret</text>
+
+  <line x1="415" y1="74" x2="415" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="650" y1="74" x2="650" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="533" y="90" text-anchor="middle" fill="#666" font-size="10">HTTPS</text>
 
   <!-- ===== Layer 2: Edge ===== -->
   <rect x="80" y="100" width="700" height="88" rx="8" fill="#f8f9fa" stroke="#bbb" stroke-width="1"/>

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -46,7 +46,7 @@
   <text x="415" y="63" text-anchor="middle" font-size="9" fill="#666">自注册 (DCR) + PKCE · 无需 Secret</text>
 
   <rect x="560" y="26" width="180" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
-  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Quick Desktop</text>
+  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Amazon Quick</text>
   <text x="650" y="63" text-anchor="middle" font-size="9" fill="#666">共享 Client ID + Secret</text>
 
   <line x1="415" y1="74" x2="415" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -46,7 +46,7 @@
   <text x="415" y="63" text-anchor="middle" font-size="9" fill="#666">自注册 (DCR) + PKCE · 无需 Secret</text>
 
   <rect x="560" y="26" width="180" height="48" rx="6" fill="#fff" stroke="#333" stroke-width="1.5"/>
-  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Amazon Quick</text>
+  <text x="650" y="46" text-anchor="middle" font-size="13" font-weight="500">Quick Desktop</text>
   <text x="650" y="63" text-anchor="middle" font-size="9" fill="#666">共享 Client ID + Secret</text>
 
   <line x1="415" y1="74" x2="415" y2="100" stroke="#333" stroke-width="1.5" marker-end="url(#arr)"/>


### PR DESCRIPTION
The client layer of the architecture diagram had a single "Quick Desktop" box, so it only showed one of the two ways into this service. Kiro / Claude Code / Codex self-register via DCR with PKCE and never see a client secret — a different flow, and the more common one — yet it was invisible.

## Changes

- **Diagram (both languages):** two client boxes side by side, each labelled with what authenticates it — `Kiro · Claude Code · Codex` (self-register via DCR + PKCE, no secret) and `Quick Desktop` (shared Client ID + Secret). The client layer moved up so the boxes no longer overlap the edge band, and the `HTTPS` label sits between the two arrows instead of crowding the left box. Rendered both to PNG to check the layout.
- **README (both languages):** the request-path sentence named only Quick Desktop; it now names both paths.
- **`docs/agent/architecture.md`:** same fix in the request-lifecycle sketch, which was inconsistent with its own text — it describes both onboarding paths a few lines further down.

The box is labelled **Amazon Quick**, not "Quick Desktop". This service is a plain remote MCP endpoint, so Quick's web client reaches it just as well as the desktop app — naming the desktop app implied a narrower surface than we have. "Quick Desktop" stays in `docs/quick-desktop-setup_{en,zh}.md`, which really is about the desktop client and its screenshots.

Also checked and found nothing else stale: the README hard-codes no lark-cli version or tool count, the diagram's "28 Tier1" still matches `docker/tier1.json`, and no leftover custom-domain content remains after #36. The `e.g. Quick Desktop` in `docs/security_{en,zh}.md` is left as is — there it illustrates who holds the MCP token, where one example reads fine.

---

架构图的客户端层只有一个 "Quick Desktop" 框，所以图上只体现了两条接入路径中的一条。Kiro / Claude Code / Codex 走 DCR 自注册 + PKCE、从不接触 client secret，是另一条路径，而且是更常用的那条，但图上完全看不到。

## 改动

- **架构图（中英两版）：** 并列两个客户端框，各自标注认证方式——`Kiro · Claude Code · Codex`（自注册 DCR + PKCE，无需 Secret）和 `Quick Desktop`（共享 Client ID + Secret）。客户端层整体上移，两个框不再压在入口层的浅灰区上；`HTTPS` 标签移到两条箭头中间，不再挤在左框下沿。两版都渲染成 PNG 目视确认过布局。
- **README（中英两版）：** 描述请求链路的那句话只提了 Quick Desktop，现在两条路径都写上。
- **`docs/agent/architecture.md`：** 请求生命周期示意图同样只举一例，而它下面几行就详细描述了两条接入路径，自相矛盾，一并修正。

框上写的是 **Amazon Quick**，不是 "Quick Desktop"。本服务就是一个普通的 remote MCP 端点，Quick 网页版和桌面版都能连——只写桌面版会让接入面显得比实际更窄。"Quick Desktop" 保留在 `docs/quick-desktop-setup_{en,zh}.md` 里，那份文档讲的确实是桌面客户端的配置步骤和截图。

另外核对了一遍，没有其他过时内容：README 没有硬编码 lark-cli 版本号或工具数量，图里的 "28 Tier1" 与 `docker/tier1.json` 一致，#36 之后也没有残留的自定义域名内容。`docs/security_{en,zh}.md` 里的 `如 Quick Desktop` 保持原样——那里是说明谁持有 MCP Token，举一个例子读起来没问题。
