### PR TITLE
fix(scopes): exclude unavailable VC screenshot permission

### DIFF
--- a/docker/generate-tools.js
+++ b/docker/generate-tools.js
@@ -56,13 +56,11 @@ let scopeMapVersion = 'unknown';
 // shortcut-scopes.json — the authoritative upstream-extracted shortcut list. Used
 // to admit no-plus shortcuts while excluding no-plus raw-API resource groups.
 const noPlusShortcuts = {};
-// Shortcuts upstream declares bot-only (AuthTypes without "user"). They must never
-// become MCP tools: this server only ever holds a user token, so calling one fails
-// with "user access token not support", and the adapted skills state plainly that
-// no tool exists for them. lark-cli already hides bot-only commands from `--help`,
-// but only when a user-token env var is set during the build — an incidental
-// mechanism. Filtering on this set makes the exclusion explicit and testable.
-const botOnlyShortcuts = new Set();
+// Shortcuts marked non-user-callable, either by upstream AuthTypes or an
+// evidence-backed ordinary-app override. They must never become MCP tools: this
+// server only ever holds a user token. Filtering on this set makes the exclusion
+// explicit and testable instead of depending on lark-cli `--help` visibility.
+const userUnavailableShortcuts = new Set();
 if (fs.existsSync(SCOPES_FILE)) {
   const raw = JSON.parse(fs.readFileSync(SCOPES_FILE, 'utf8'));
   const scopeData = raw.shortcuts || raw;
@@ -70,12 +68,12 @@ if (fs.existsSync(SCOPES_FILE)) {
   for (const entry of scopeData) {
     const key = `${entry.service}:${entry.command}`;
     scopeMap[key] = entry.scopes || [];
-    if (entry.userCallable === false) botOnlyShortcuts.add(key);
+    if (entry.userCallable === false) userUnavailableShortcuts.add(key);
     if (!entry.command.startsWith('+')) {
       (noPlusShortcuts[entry.service] ||= new Set()).add(entry.command);
     }
   }
-  console.log(`Scope map loaded: ${Object.keys(scopeMap).length} entries (lark-cli ${scopeMapVersion}), ${botOnlyShortcuts.size} bot-only excluded`);
+  console.log(`Scope map loaded: ${Object.keys(scopeMap).length} entries (lark-cli ${scopeMapVersion}), ${userUnavailableShortcuts.size} non-user-callable excluded`);
 }
 
 console.log('Generating tool catalog from lark-cli...');
@@ -127,8 +125,8 @@ let schemaExtracted = 0;
 for (const service of services) {
   const { shortcuts } = discoverShortcuts(service, noPlusShortcuts[service] || new Set());
   for (const { command, description } of shortcuts) {
-    // Bot-only upstream: not user-callable, so never expose it as a tool.
-    if (botOnlyShortcuts.has(`${service}:${command}`)) continue;
+    // Not callable by this user-only deployment, so never expose it as a tool.
+    if (userUnavailableShortcuts.has(`${service}:${command}`)) continue;
     const cmdHelp = run('lark-cli', service, command, '--help');
     const { flags, supportsYes, supportsPrintSchema } = parseFlags(cmdHelp);
     // Translate CLI-speak out of every agent-facing description (@file/stdin

--- a/docker/shortcut-scopes.json
+++ b/docker/shortcut-scopes.json
@@ -4007,9 +4007,8 @@
     {
       "service": "vc",
       "command": "+meeting-screenshot",
-      "scopes": [
-        "vc:meeting.realtime:read"
-      ]
+      "scopes": [],
+      "userCallable": false
     },
     {
       "service": "vc",

--- a/docker/skills/lark-meeting/SKILL.md
+++ b/docker/skills/lark-meeting/SKILL.md
@@ -13,9 +13,9 @@ description: "飞书视频会议：查询会议记录与会议产物(纪要/逐�
 
 MCP server 始终以**用户身份**调用，无法切换为**应用身份**（机器人身份）。因此：
 
-- 用户身份路径可用：发现当前登录用户正在参加的会议、读取该会议的会中事件、发送会中消息、读取当前会议画面（`lark_vc_meeting_screenshot`）、操作会中倒计时（`lark_vc_meeting_countdown`）、查询会议与妙记产物。
-- ⚠️ 应用身份路径在 MCP server 上不可用：应用机器人发起或真实入会（`lark_vc_meeting_join`，含 `action="start"`）、离会（`lark_vc_meeting_leave`），以及带 `user_id` 的应用身份活跃会议发现（`lark_vc_meeting_list_active(user_id=...)`）。邀请参会人和结束会议更进一步——它们只接受应用身份，MCP server 的工具目录里连对应工具都没有。遇到这类请求时说明限制并停止，不要为了让调用成功而替换身份或改用其他工具。
-- `meeting_id` 从哪条身份路径拿到，后续读事件、发消息、截图、操作倒计时就沿用同一条路径；通过 MCP server 时始终是用户身份发现的 `meeting_id`。
+- 用户身份路径可用：发现当前登录用户正在参加的会议、读取该会议的会中事件、发送会中消息、操作会中倒计时（`lark_vc_meeting_countdown`）、查询会议与妙记产物。
+- ⚠️ 应用身份路径在 MCP server 上不可用：应用机器人发起或真实入会（`lark_vc_meeting_join`，含 `action="start"`）、离会（`lark_vc_meeting_leave`），以及带 `user_id` 的应用身份活跃会议发现（`lark_vc_meeting_list_active(user_id=...)`）。邀请参会人、结束会议和会议截图也不在 user-only MCP 工具目录中。遇到这类请求时说明限制并停止，不要为了让调用成功而替换身份或改用其他工具。
+- `meeting_id` 从哪条身份路径拿到，后续读事件、发消息、操作倒计时就沿用同一条路径；通过 MCP server 时始终是用户身份发现的 `meeting_id`。
 - 向用户说明结果时使用"用户身份"或"应用身份"，不要暴露 `user` / `bot` 这类内部缩写。
 
 ## 领域模型与概念
@@ -92,8 +92,8 @@ lark_vc_meeting_events(meeting_id="<meeting_id>", page_all=true)
 - `lark_get_skill(domain="meeting", section="scenes/query-minutes-and-artifacts")`（查询妙记及其产物）：已有妙记 URL / `minute_token`，或按标题、所有者、参与者搜索妙记；读取总结、待办、章节、关键词、逐字稿，下载原始音视频，或查询关联智能纪要。
 - `lark_get_skill(domain="meeting", section="scenes/create-and-edit-minutes")`（生成和修改妙记、管理妙记权限）：将本地音视频生成妙记、逐字稿、总结、待办或章节；修改妙记标题、总结、待办、关键词或说话人；申请妙记权限，或查看、分配妙记协作者权限。
 - `lark_get_skill(domain="meeting", section="scenes/query-note-and-artifacts")`（查询智能纪要及关联产物）：已有 `note_id`、智能纪要 Docx URL/token，或需要查询纪要正文、逐字稿、妙记和共享文档等关联产物。
-- `lark_get_skill(domain="meeting", section="scenes/live-meeting-attend")`（应用机器人参会与会中互动）：完整编排应用机器人的活跃会议发现、发起或加入、邀请、事件拉取、会议截图、文本/表情/倒计时互动、结束会议和明确授权后的离会。⚠️ 其中的发起 / 入会 / 邀请 / 结束 / 离会是应用身份写操作，MCP server 不可用。
-- `lark_get_skill(domain="meeting", section="scenes/live-meeting-interact")`（会中事件与会中互动）：在不触发新的入会/离会操作时，使用用户身份查询活跃会议、查看发言/聊天/共享内容、按需读取当前会议画面，或发送文本/表情、操作倒计时。
+- `lark_get_skill(domain="meeting", section="scenes/live-meeting-attend")`（应用机器人参会与会中互动）：完整编排应用机器人的活跃会议发现、发起或加入、邀请、事件拉取、文本/表情/倒计时互动、结束会议和明确授权后的离会。⚠️ 其中的发起 / 入会 / 邀请 / 结束 / 离会是应用身份写操作，MCP server 不可用；会议截图也不在 user-only MCP 工具目录中。
+- `lark_get_skill(domain="meeting", section="scenes/live-meeting-interact")`（会中事件与会中互动）：在不触发新的入会/离会操作时，使用用户身份查询活跃会议、查看发言/聊天/共享内容，或发送文本/表情、操作倒计时。
 
 ## 命令参考
 
@@ -106,7 +106,7 @@ lark_vc_meeting_events(meeting_id="<meeting_id>", page_all=true)
 | `lark_vc_meeting_list_active` | 发现当前可见的进行中会议 | `lark_get_skill(domain="meeting", section="lark-vc-meeting-list-active")` |
 | `lark_vc_meeting_events` | 读取会中事件和共享内容 | `lark_get_skill(domain="meeting", section="lark-vc-meeting-events")` |
 | `lark_vc_meeting_message_send` | 发送会中文本消息或表情 | `lark_get_skill(domain="meeting", section="lark-vc-meeting-message-send")` |
-| `lark_vc_meeting_screenshot` | 获取视频会议截图 | `lark_get_skill(domain="meeting", section="lark-vc-meeting-screenshot")` |
+| 会议截图（当前不可用） | 上游接口依赖普通应用无法导入的权限，不在 user-only MCP 工具目录中 | `lark_get_skill(domain="meeting", section="lark-vc-meeting-screenshot")` |
 | `lark_vc_meeting_countdown` | 设置、延长、提前结束或关闭会中倒计时 | `lark_get_skill(domain="meeting", section="lark-vc-meeting-countdown")` |
 | `lark_vc_meeting_join` | 让应用机器人发起或加入会议（⚠️ 应用身份，MCP server 不可用） | `lark_get_skill(domain="meeting", section="lark-vc-agent-meeting-join")` |
 | 邀请参会人（应用身份能力） | 上游仅支持应用身份邀请指定用户或全部合格日程参会人；⚠️ MCP server 工具目录中无对应工具，无法调用 | `lark_get_skill(domain="meeting", section="lark-vc-agent-meeting-invite")` |

--- a/docker/skills/lark-meeting/references/lark-vc-meeting-screenshot.md
+++ b/docker/skills/lark-meeting/references/lark-vc-meeting-screenshot.md
@@ -1,46 +1,23 @@
-# lark_vc_meeting_screenshot
+# 会议截图（MCP server 不可用）
 
-获取视频会议截图，并保存为 JPEG。只读操作。
+当前 user-only Remote MCP 不暴露会议截图能力，也不会为它生成增量授权链接。
 
-本工具对应 shortcut：`lark_vc_meeting_screenshot`（调用视频会议实时画面接口）。
+## 不可用原因
 
-（认证由 MCP server 自动处理，始终以用户身份执行。）
+- 上游 `vc +meeting-screenshot` shortcut 调用 `/open-apis/vc/v1/bots/screenshot`。
+- 上游声明的权限为 `vc:meeting.realtime:read`，但飞书开放平台不允许普通应用导入该权限。
+- 虽然上游元数据把用户身份列为可用身份，但接口路径和开放平台实测均表明该能力不适用于本项目的普通 user-OAuth 部署。
 
-## 常用用法
+因此，该 shortcut 在生成的 scope 元数据中固定为 `userCallable: false`、`scopes: []`，并从 MCP 工具目录、应用权限导入清单和增量授权 allowlist 中排除。
 
-```
-# 截图，文件写入默认目录
-lark_vc_meeting_screenshot(meeting_id="<long_meeting_id>")
+## 处理规则
 
-# 指定输出路径
-lark_vc_meeting_screenshot(meeting_id="<long_meeting_id>", output="./meeting-screenshots/current.jpg")
-```
-
-## 参数
-
-| 参数 | 必填 | 说明 |
-| --- | --- | --- |
-| `meeting_id` | 是 | 长数字会议 ID，不接受 9 位会议号；只有会议号时，先用同一身份调用 `lark_vc_meeting_list_active` 获取。 |
-| `output` | 否 | 指定 JPEG 文件名或包含子目录的相对路径；相对于工具执行时的工作目录。 |
-| `overwrite` | 否 | 布尔值。目标文件已存在时允许替换；不传时调用会失败并保留原文件。 |
-
-## 身份要求
-
-使用发现 `meeting_id` 时的同一身份。MCP server 始终以用户身份调用，因此要求**当前登录用户正在该会议中**。
-
-⚠️ 应用身份截图（要求应用机器人已入会并具备会中读取权限）在 MCP server 上不可用；`meeting_id` 来自应用身份路径时，说明限制并停止，不要改用用户身份重试。
-
-所需权限：`vc:meeting.realtime:read`。
-
-## 文件路径与结果
-
-- 未指定 `output` 时，默认写入工作目录下的 `meeting-screenshots/<meeting_id>-<UTC timestamp>.jpg`。
-- `output` 可以只写文件名，也可以包含多级子目录；父目录会自动创建。
-- 不接受绝对路径，也不接受解析后超出工作目录的 `..` 或符号链接路径。
-- 成功结果包含绝对文件路径、字节数、JPEG content type、SHA-256 和服务端 `log_id`。工具只返回这些文本字段，不会把图片内容本身返回给调用方。
-- 服务端决定截图内容并校验会议是否满足条件；调用方不能指定要截取的区域或共享内容。失败不会替换已有文件。
+- 不要尝试调用会议截图，也不要用其他工具名、原生 API 或身份切换绕过目录限制。
+- 不要把 `vc:meeting.realtime:read` 加回应用权限导入清单或增量授权 URL。
+- 优先通过会中事件、字幕、聊天和可读取的共享文档回答问题。
+- 用户问题必须依赖当前会议画面时，说明当前 user-only Remote MCP 无法读取会议截图，并停止该分支。
 
 ## 相关场景
 
 - `lark_get_skill(domain="meeting", section="scenes/live-meeting-interact")` — 会中事件与会中互动
-- `lark_get_skill(domain="meeting", section="lark-vc-meeting-list-active")` — 发现当前进行中会议 ID
+- `lark_get_skill(domain="meeting", section="lark-vc-meeting-events")` — 读取会中结构化事件与共享内容

--- a/docker/skills/lark-meeting/scenes/live-meeting-interact.md
+++ b/docker/skills/lark-meeting/scenes/live-meeting-interact.md
@@ -51,22 +51,11 @@ lark_vc_meeting_events(meeting_id="<meeting_id>", page_all=true, format="pretty"
 
 精确事件 schema 和后续调用见 `lark_get_skill(domain="meeting", section="lark-vc-meeting-events")` 的文档上下文部分。
 
-## 读取当前会议画面
+## 会议截图不可用
 
-仅当用户的问题必须读取当前会议合成画面中的视觉信息，且结构化内容不足以回答时读取画面。适用任务包括识别投屏中实际显示的网页地址、界面状态或报错，理解图表、幻灯片等依赖版式或图像的信息，以及查看摄像头画面。
+当前 user-only Remote MCP 不提供会议截图：上游 shortcut 调用 `/open-apis/vc/v1/bots/screenshot`，并依赖普通应用无法在飞书开放平台导入的 `vc:meeting.realtime:read`。不要尝试调用、生成增量授权链接或用其他身份重试。
 
-事件、字幕、聊天或可直接读取的共享文档已经足够回答时，不要截图；会议内容查询、总结或共享文档定位也不以截图兜底，不要仅因为会议正在进行就读取画面。
-
-需要读取时执行：
-
-```
-lark_vc_meeting_screenshot(meeting_id="<meeting_id>")
-```
-
-- 沿用 `meeting_id` 的来源身份。通过 MCP server 时恒为用户身份，要求当前登录用户正在该会议中。
-- 工具只返回文件路径和元数据（字节数、content type、SHA-256、`log_id`），不会把图片内容本身返回给调用方。
-
-身份、会议 ID、输出文件和失败处理见 `lark_get_skill(domain="meeting", section="lark-vc-meeting-screenshot")`。
+优先使用会中事件、字幕、聊天和可读取的共享文档回答问题；必须依赖当前画面时，明确说明该部署无法读取会议截图。完整限制见 `lark_get_skill(domain="meeting", section="lark-vc-meeting-screenshot")`。
 
 ## 发送会中文本或表情
 

--- a/docs/app-setup_en.md
+++ b/docs/app-setup_en.md
@@ -48,7 +48,7 @@ avoids that loop. It does **not** widen what users see at first authorization (s
 minimal set); the only cost is a larger declared permission ceiling and more items for
 your admin to approve.
 
-Scope list (237 entries, copy-paste ready):
+Scope list (236 entries, copy-paste ready):
 
 ```json
 {
@@ -274,7 +274,6 @@ Scope list (237 entries, copy-paste ready):
       "vc:meeting.interaction:write",
       "vc:meeting.meetingevent:read",
       "vc:meeting.message:write",
-      "vc:meeting.realtime:read",
       "vc:meeting.search:read",
       "vc:meeting:readonly",
       "vc:note:read",

--- a/docs/app-setup_zh.md
+++ b/docs/app-setup_zh.md
@@ -38,7 +38,7 @@ Manager。请妥善保管，不要提交到代码库。
 反复。它**不影响**用户首次授权看到的范围（那始终是最小集），代价只是应用声明的权限上限更大、
 管理员审核项更多。
 
-scope 清单（237 条，可直接复制导入）：
+scope 清单（236 条，可直接复制导入）：
 
 ```json
 {
@@ -264,7 +264,6 @@ scope 清单（237 条，可直接复制导入）：
       "vc:meeting.interaction:write",
       "vc:meeting.meetingevent:read",
       "vc:meeting.message:write",
-      "vc:meeting.realtime:read",
       "vc:meeting.search:read",
       "vc:meeting:readonly",
       "vc:note:read",

--- a/infra/test/__snapshots__/snapshot.test.ts.snap
+++ b/infra/test/__snapshots__/snapshot.test.ts.snap
@@ -2108,7 +2108,7 @@ exports[`CDK Snapshot Tests > OAuthStack matches snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-west-2",
-          "S3Key": "80e35badc893ef09b012220feb6f7a46f2f2662c2321750561e584047e39601f.zip",
+          "S3Key": "fcde69de2e7fb17f1e056206ffc57afb2a88688df4415d25636080ce31b0e662.zip",
         },
         "Environment": {
           "Variables": {

--- a/infra/test/scope-coverage.test.ts
+++ b/infra/test/scope-coverage.test.ts
@@ -190,28 +190,42 @@ describe("scope coverage", () => {
     ).toEqual([]);
   });
 
-  // A shortcut whose upstream AuthTypes omits "user" cannot be invoked with a user
-  // token at all. The extractor marks those `userCallable: false`, generate-tools.js
-  // skips them, and the adapted skills tell the agent no tool exists. These three
-  // assertions keep that chain honest — before them the exclusion rested entirely on
-  // lark-cli hiding bot-only commands from `--help`, which it only does when a
-  // user-token env var happens to be set during the image build.
-  const botOnly = shortcutScopes.shortcuts.filter((s) => s.userCallable === false);
+  // A shortcut can be unavailable to this user-only deployment because upstream
+  // AuthTypes omits "user", or because an evidence-backed override records that an
+  // ordinary app cannot obtain the declared permission. The extractor marks those
+  // `userCallable: false`, generate-tools.js skips them, and adapted skills explain
+  // the limitation instead of presenting an unusable tool.
+  const userUnavailable = shortcutScopes.shortcuts.filter(
+    (s) => s.userCallable === false,
+  );
 
-  it("bot-only shortcuts are marked and carry no user scopes", () => {
-    // Non-vacuous: 1.0.92 ships four (im +messages-edit, vc +meeting-end,
-    // vc +meeting-invite, event +subscribe). Zero means the AuthTypes gate broke.
-    expect(botOnly.length).toBeGreaterThan(0);
+  it("non-user-callable shortcuts are marked and carry no user scopes", () => {
     expect(
-      botOnly.filter((s) => (s.scopes || []).length > 0).map((s) => `${s.service} ${s.command}`),
-      "a bot-only shortcut must grant no user scopes",
+      userUnavailable.map((s) => `${s.service} ${s.command}`).sort(),
+    ).toEqual([
+      "event +subscribe",
+      "im +messages-edit",
+      "vc +meeting-end",
+      "vc +meeting-invite",
+      "vc +meeting-screenshot",
+    ]);
+    expect(
+      userUnavailable
+        .filter((s) => (s.scopes || []).length > 0)
+        .map((s) => `${s.service} ${s.command}`),
+      "a non-user-callable shortcut must grant no user scopes",
     ).toEqual([]);
+
+    const screenshot = userUnavailable.find(
+      (s) => s.service === "vc" && s.command === "+meeting-screenshot",
+    );
+    expect(screenshot?.scopes).toEqual([]);
   });
 
-  it("generate-tools.js filters bot-only shortcuts out of the catalog", () => {
+  it("generate-tools.js filters non-user-callable shortcuts out of the catalog", () => {
     const gen = readFileSync(resolve(ROOT, "docker/generate-tools.js"), "utf-8");
     expect(gen).toContain("userCallable === false");
-    expect(gen).toMatch(/botOnlyShortcuts\.has\(/);
+    expect(gen).toMatch(/userUnavailableShortcuts\.has\(/);
   });
 
   // The generator's own env is what makes lark-cli hide bot-only commands. Setting it

--- a/lambda/token-refresh-shim/scope-allowlist.ts
+++ b/lambda/token-refresh-shim/scope-allowlist.ts
@@ -238,7 +238,6 @@ export const SCOPE_ALLOWLIST: ReadonlySet<string> = new Set([
   "vc:meeting.interaction:write",
   "vc:meeting.meetingevent:read",
   "vc:meeting.message:write",
-  "vc:meeting.realtime:read",
   "vc:meeting.search:read",
   "vc:meeting:readonly",
   "vc:note:read",

--- a/scripts/.audit-snapshot.txt
+++ b/scripts/.audit-snapshot.txt
@@ -489,7 +489,6 @@ vc|+meeting-join|write|0|vc:meeting.bot.join:write
 vc|+meeting-leave|write|0|vc:meeting.bot.join:write
 vc|+meeting-list-active|read|0|vc:meeting.meetingevent:read
 vc|+meeting-message-send|write|0|vc:meeting.message:write
-vc|+meeting-screenshot|read|0|vc:meeting.realtime:read
 vc|+recording|read|0|vc:record:readonly
 vc|+search|read|0|vc:meeting.search:read
 whiteboard|+export|read|0|board:whiteboard:node:read

--- a/scripts/audit-tools.sh
+++ b/scripts/audit-tools.sh
@@ -128,13 +128,13 @@ if os.path.exists(SCOPES):
             f"{sorted(list(extra))[:5]}…")
     # The reverse direction is NOT an invariant: shortcut-scopes.json is extracted
     # from lark-cli's Go source and is deliberately a SUPERSET of the catalog. It
-    # keeps deprecated/renamed aliases, and bot-only shortcuts (AuthTypes without
-    # "user") that never render into `--help` and so never become tools. Reporting
+    # keeps deprecated/renamed aliases, and non-user-callable shortcuts that never
+    # become tools. Reporting
     # that as a failure made this tier permanently red and hid real regressions.
     if missing:
         print(f"  \033[33m·\033[0m {len(missing)} scope-map entry(ies) are not catalog "
               f"tools — expected: the scope map is a Go-source superset (deprecated "
-              f"aliases + bot-only shortcuts). Sample: {sorted(list(missing))[:5]}")
+              f"aliases + non-user-callable shortcuts). Sample: {sorted(list(missing))[:5]}")
 
 # ── B. Schema health ──────────────────────────────────────────────────────
 print("\n── B. Schema health ──")
@@ -347,8 +347,8 @@ else:
 # time. Two failure classes, both silent, both seen in real bumps:
 #
 #   1. Dead tool name. shortcut-scopes.json is a Go-source SUPERSET (hidden
-#      aliases, plus bot-only shortcuts whose AuthTypes omit "user" and which
-#      therefore never reach `--help` and never become tools). Validating docs
+#      aliases, plus shortcuts marked non-user-callable by AuthTypes or an
+#      evidence-backed ordinary-app override). Validating docs
 #      against it passes names the server does not expose; the agent then gets
 #      "tool does not exist". The catalog below is the only authority.
 #   2. Flag type mismatch. A stringArray flag written as a comma-joined string
@@ -439,23 +439,23 @@ else:
             print(f"      {m}")
 
 # End-to-end counterpart of the scope-coverage unit assertions: prove the shortcuts
-# upstream declares bot-only really are absent from the catalog the server serves.
+# marks non-user-callable really are absent from the catalog the server serves.
 if os.path.exists(SCOPES):
     with open(SCOPES) as f:
         _sc = json.load(f).get('shortcuts', [])
-    bot_only = [s for s in _sc if s.get('userCallable') is False]
+    user_unavailable = [s for s in _sc if s.get('userCallable') is False]
     leaked = [f"{s['service']} {s['command']}"
-              for s in bot_only
+              for s in user_unavailable
               if (s['service'], s['command']) in
               {(t['service'], t['command']) for t in tools}]
-    if not bot_only:
-        bad("no shortcut is marked userCallable:false — the AuthTypes gate in "
+    if not user_unavailable:
+        bad("no shortcut is marked userCallable:false — the extraction gate in "
             "scripts/extract-shortcut-scopes.py has stopped working")
     elif leaked:
-        bad(f"{len(leaked)} bot-only shortcut(s) reached the catalog — the adapted "
+        bad(f"{len(leaked)} non-user-callable shortcut(s) reached the catalog — the adapted "
             f"skills claim no tool exists for them: {leaked}")
     else:
-        ok(f"all {len(bot_only)} bot-only shortcut(s) absent from the catalog")
+        ok(f"all {len(user_unavailable)} non-user-callable shortcut(s) absent from the catalog")
 
 # ── Summary ────────────────────────────────────────────────────────────────
 print(f"\n──────────────────────────────────")

--- a/scripts/extract-shortcut-scopes.py
+++ b/scripts/extract-shortcut-scopes.py
@@ -12,6 +12,8 @@ Produces docker/shortcut-scopes.json with UserScopes-first extraction strategy:
     generic Scopes fallback (upstream may declare it under both)
   - Exclude every scope of a shortcut whose AuthTypes omits "user" (the
     endpoint rejects user tokens, so nothing there is user-grantable)
+  - Apply evidence-backed user-unavailable overrides when upstream AuthTypes is
+    wrong or the declared user scope is not grantable by ordinary apps
 
 Handles:
   - Direct []string{...} literals
@@ -24,6 +26,18 @@ import json
 import re
 import sys
 from pathlib import Path
+
+
+# Shortcut-scoped overrides are intentionally narrow and require concrete
+# evidence that an ordinary user-OAuth deployment cannot call the endpoint.
+USER_UNAVAILABLE_SHORTCUTS = {
+    ("vc", "+meeting-screenshot"): (
+        "calls /open-apis/vc/v1/bots/screenshot and requires "
+        "vc:meeting.realtime:read, which the Feishu developer console rejects "
+        "for ordinary apps"
+    ),
+}
+
 
 def main():
     if len(sys.argv) < 2:
@@ -131,6 +145,12 @@ def main():
             return [], False
         return list(dict.fromkeys(base_scopes + cond_scopes)), True
 
+    def apply_user_unavailable_override(service, command, scopes, user_callable):
+        """Force evidence-backed ordinary-app exclusions into generated metadata."""
+        if (service, command) in USER_UNAVAILABLE_SHORTCUTS:
+            return [], False
+        return scopes, user_callable
+
     def extract_scope_field(body, field):
         """Extract scope list from a struct field, resolving variable references."""
         # Direct []string{...}
@@ -216,6 +236,9 @@ def main():
                 base_scopes, cond_scopes, bot_scopes, auth_types,
                 from_user_field=bool(has_user and user_scopes),
                 has_auth=has_auth,
+            )
+            all_scopes, user_callable = apply_user_unavailable_override(
+                service, command, all_scopes, user_callable
             )
 
             entry = {
@@ -332,9 +355,12 @@ def main():
             for cm in config_cmd_pattern.finditer(content):
                 cmd = cm.group(1)
                 if (service, cmd) not in extracted_keys:
+                    entry_scopes, entry_user_callable = apply_user_unavailable_override(
+                        service, cmd, all_scopes, user_callable
+                    )
                     entry = {"service": service, "command": cmd,
-                             "scopes": all_scopes}
-                    if not user_callable:
+                             "scopes": entry_scopes}
+                    if not entry_user_callable:
                         entry["userCallable"] = False
                     results.append(entry)
                     extracted_keys.add((service, cmd))


### PR DESCRIPTION
## English

### Summary

- mark `vc +meeting-screenshot` as non-user-callable for ordinary user-OAuth deployments because it calls `/open-apis/vc/v1/bots/screenshot` and its `vc:meeting.realtime:read` scope is rejected by the Feishu developer console
- exclude the shortcut from the MCP catalog and remove the scope from the incremental-authorization allowlist and app-setup import lists
- update the meeting skill to state that screenshots are unavailable instead of presenting an unusable tool
- generalize catalog generation and audit wording from bot-only to non-user-callable, with an exact five-shortcut regression assertion

### Verification

- `./scripts/test.sh` — 33 test files, 692 tests passed
- `scripts/test-smoke-docker.sh` — 6/6 passed
- `scripts/audit-tools.sh --catalog ...` — 18/18 passed
- final catalog: 508 shortcuts, 234 raw APIs, 29 composite payload schemas
- app-setup import list: 236 scopes; English and Chinese JSON blocks are byte-identical
- `vc +meeting-screenshot` and `vc:meeting.realtime:read` are absent from all user-callable surfaces

---

## 中文

### 摘要

- 将 `vc +meeting-screenshot` 标记为普通 user-OAuth 部署不可调用：该 shortcut 调用 `/open-apis/vc/v1/bots/screenshot`，且其 `vc:meeting.realtime:read` 权限无法在飞书开放平台导入
- 从 MCP 工具目录排除该 shortcut，并从增量授权 allowlist 和应用配置导入清单删除该 scope
- 更新 meeting skill，明确会议截图当前不可用，不再展示不可调用工具
- 将目录生成与审计中的 bot-only 表述泛化为 non-user-callable，并精确锁定 5 个不可调用 shortcut

### 验证

- `./scripts/test.sh` — 33 个测试文件、692 条测试通过
- `scripts/test-smoke-docker.sh` — 6/6 通过
- `scripts/audit-tools.sh --catalog ...` — 18/18 通过
- 最终目录：508 个 shortcut、234 个 raw API、29 个复合 payload schema
- 应用配置导入清单：236 条；中英文 JSON 块字节一致
- 所有用户可调用表面均不再包含 `vc +meeting-screenshot` 和 `vc:meeting.realtime:read`